### PR TITLE
feat: add highlights input form to design system

### DIFF
--- a/components/molecules/HighlightInput/highlight-input-form.tsx
+++ b/components/molecules/HighlightInput/highlight-input-form.tsx
@@ -1,0 +1,74 @@
+import Button from "components/atoms/Button/button";
+import { useEffect, useRef, useState } from "react";
+
+const HighlightInputForm = (): JSX.Element => {
+  const [isDivFocused, setIsDivFocused] = useState<boolean>(false);
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const [bodyText, setBodyText] = useState<string>("");
+  const [title, setTitle] = useState<string>("");
+  const ref = useRef<HTMLFormElement>(null);
+
+  useEffect(() => {
+    const checkIfClickedOutside = (e: any) => {
+      // If the menu is open and the clicked target is not within the menu,
+      // then close the menu
+      if (isDivFocused && ref.current && !ref.current.contains(e.target)) {
+        setIsDivFocused(false);
+      }
+    };
+    document.addEventListener("mousedown", checkIfClickedOutside);
+
+    return () => {
+      // Cleanup the event listener
+      document.removeEventListener("mousedown", checkIfClickedOutside);
+    };
+  }, [isDivFocused]);
+
+  // Handle submit highlights
+  const handlePostHighlight = () => {
+    // Trigger api call to post highlight
+    setBodyText("");
+    setTitle("");
+  };
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        handlePostHighlight();
+        setIsDivFocused(false);
+      }}
+      ref={ref}
+      className="flex flex-col gap-4"
+    >
+      <div
+        onClick={() => {
+          setIsDivFocused(true);
+        }}
+        className="bg-white p-2 flex border rounded-lg overflow-hidden flex-col gap-2 "
+      >
+        <input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className=" focus:outline-none"
+          type="text"
+          placeholder={isDivFocused ? "Add title (optional)" : "Highlight your merged PRs and provide a link!"}
+        />
+        <textarea
+          value={bodyText}
+          onChange={(e) => setBodyText(e.target.value)}
+          ref={textAreaRef}
+          className={`resize-none focus:outline-none ${!isDivFocused ? "hidden" : ""}`}
+        />
+      </div>
+
+      {isDivFocused && (
+        <Button disabled={!bodyText} className="ml-auto" type="primary">
+          Post
+        </Button>
+      )}
+    </form>
+  );
+};
+
+export default HighlightInputForm;

--- a/components/molecules/HighlightInput/highlight-input-form.tsx
+++ b/components/molecules/HighlightInput/highlight-input-form.tsx
@@ -54,12 +54,12 @@ const HighlightInputForm = (): JSX.Element => {
         onClick={() => {
           setIsDivFocused(true);
         }}
-        className="bg-white  flex border rounded-lg overflow-hidden flex-col gap-2 "
+        className="bg-white p-2 flex border rounded-lg overflow-hidden flex-col gap-2 "
       >
         <input
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          className=" focus:outline-none p-2"
+          className=" focus:outline-none "
           type="text"
           placeholder={isDivFocused ? "Add title (optional)" : "Highlight your merged PRs and provide a link!"}
         />
@@ -68,7 +68,7 @@ const HighlightInputForm = (): JSX.Element => {
           value={bodyText}
           onChange={(e) => handleTextAreaInputChange(e)}
           ref={textAreaRef}
-          className={`resize-none text-light-slate-11 p-2 mx-1 mb-2 transition focus:outline-none focus:border border-light-slate-2 rounded-lg ${
+          className={`resize-none text-light-slate-11 mb-2 transition focus:outline-none rounded-lg ${
             !isDivFocused ? "hidden" : ""
           }`}
         />

--- a/components/molecules/HighlightInput/highlight-input-form.tsx
+++ b/components/molecules/HighlightInput/highlight-input-form.tsx
@@ -1,8 +1,8 @@
 import Button from "components/atoms/Button/button";
-import { ChangeEvent, useEffect, useRef, useState } from "react";
+import { ChangeEvent, useEffect, useRef, useState, MouseEvent } from "react";
 
 const HighlightInputForm = (): JSX.Element => {
-  const [isDivFocused, setIsDivFocused] = useState<boolean>(false);
+  const [isDivFocused, setIsDivFocused] = useState(false);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const [bodyText, setBodyText] = useState<string>("");
   const [row, setRow] = useState<number>(1);
@@ -40,22 +40,16 @@ const HighlightInputForm = (): JSX.Element => {
   };
 
   // Handle submit highlights
-  const handlePostHighlight = () => {
+  const handlePostHighlight = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setIsDivFocused(false);
     // Trigger api call to post highlight
     setBodyText("");
     setTitle("");
   };
 
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        handlePostHighlight();
-        setIsDivFocused(false);
-      }}
-      ref={ref}
-      className="flex flex-col gap-4"
-    >
+    <form onSubmit={handlePostHighlight} ref={ref} className="flex flex-col gap-4">
       <div
         onClick={() => {
           setIsDivFocused(true);
@@ -74,7 +68,7 @@ const HighlightInputForm = (): JSX.Element => {
           value={bodyText}
           onChange={(e) => handleTextAreaInputChange(e)}
           ref={textAreaRef}
-          className={`resize-none p-2 mx-1 mb-2 transition focus:outline-none focus:border border-light-slate-2 rounded-lg ${
+          className={`resize-none text-light-slate-11 p-2 mx-1 mb-2 transition focus:outline-none focus:border border-light-slate-2 rounded-lg ${
             !isDivFocused ? "hidden" : ""
           }`}
         />

--- a/components/molecules/HighlightInput/highlight-input-form.tsx
+++ b/components/molecules/HighlightInput/highlight-input-form.tsx
@@ -1,12 +1,15 @@
 import Button from "components/atoms/Button/button";
-import { useEffect, useRef, useState } from "react";
+import { ChangeEvent, useEffect, useRef, useState } from "react";
 
 const HighlightInputForm = (): JSX.Element => {
   const [isDivFocused, setIsDivFocused] = useState<boolean>(false);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const [bodyText, setBodyText] = useState<string>("");
+  const [row, setRow] = useState<number>(1);
   const [title, setTitle] = useState<string>("");
   const ref = useRef<HTMLFormElement>(null);
+  let rowLomit = 5;
+  let messageLastScrollHeight = textAreaRef.current ? textAreaRef.current?.scrollHeight : 50;
 
   useEffect(() => {
     const checkIfClickedOutside = (e: any) => {
@@ -22,7 +25,19 @@ const HighlightInputForm = (): JSX.Element => {
       // Cleanup the event listener
       document.removeEventListener("mousedown", checkIfClickedOutside);
     };
-  }, [isDivFocused]);
+  }, [isDivFocused, bodyText]);
+
+  const handleTextAreaInputChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setBodyText(e.target.value);
+    if (row < rowLomit && textAreaRef.current && textAreaRef.current?.scrollHeight > messageLastScrollHeight) {
+      setRow((prev) => prev + 1);
+    } else if (row > 1 && textAreaRef.current && textAreaRef.current?.scrollHeight < messageLastScrollHeight) {
+      setRow((prev) => prev--);
+    }
+
+    if (!bodyText) setRow(1);
+    messageLastScrollHeight = textAreaRef.current?.scrollHeight || 65;
+  };
 
   // Handle submit highlights
   const handlePostHighlight = () => {
@@ -45,20 +60,23 @@ const HighlightInputForm = (): JSX.Element => {
         onClick={() => {
           setIsDivFocused(true);
         }}
-        className="bg-white p-2 flex border rounded-lg overflow-hidden flex-col gap-2 "
+        className="bg-white  flex border rounded-lg overflow-hidden flex-col gap-2 "
       >
         <input
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          className=" focus:outline-none"
+          className=" focus:outline-none p-2"
           type="text"
           placeholder={isDivFocused ? "Add title (optional)" : "Highlight your merged PRs and provide a link!"}
         />
         <textarea
+          rows={row}
           value={bodyText}
-          onChange={(e) => setBodyText(e.target.value)}
+          onChange={(e) => handleTextAreaInputChange(e)}
           ref={textAreaRef}
-          className={`resize-none focus:outline-none ${!isDivFocused ? "hidden" : ""}`}
+          className={`resize-none p-2 mx-1 mb-2 transition focus:outline-none focus:border border-light-slate-2 rounded-lg ${
+            !isDivFocused ? "hidden" : ""
+          }`}
         />
       </div>
 

--- a/components/molecules/HighlightInput/highlight-input-form.tsx
+++ b/components/molecules/HighlightInput/highlight-input-form.tsx
@@ -37,7 +37,7 @@ const HighlightInputForm = (): JSX.Element => {
     }
 
     if (!bodyText) setRow(1);
-    messageLastScrollHeight = textAreaRef.current?.scrollHeight || 65;
+    messageLastScrollHeight = textAreaRef.current?.scrollHeight || 60;
   };
 
   // Handle submit highlights

--- a/components/molecules/HighlightInput/highlight-input-form.tsx
+++ b/components/molecules/HighlightInput/highlight-input-form.tsx
@@ -1,21 +1,22 @@
 import Button from "components/atoms/Button/button";
-import { ChangeEvent, useEffect, useRef, useState, MouseEvent } from "react";
+
+import { ChangeEvent, useEffect, useRef, useState } from "react";
 
 const HighlightInputForm = (): JSX.Element => {
   const [isDivFocused, setIsDivFocused] = useState(false);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
-  const [bodyText, setBodyText] = useState<string>("");
-  const [row, setRow] = useState<number>(1);
-  const [title, setTitle] = useState<string>("");
+  const [bodyText, setBodyText] = useState("");
+  const [row, setRow] = useState(1);
+  const [title, setTitle] = useState("");
   const ref = useRef<HTMLFormElement>(null);
   let rowLomit = 5;
   let messageLastScrollHeight = textAreaRef.current ? textAreaRef.current?.scrollHeight : 50;
 
   useEffect(() => {
-    const checkIfClickedOutside = (e: any) => {
+    const checkIfClickedOutside = (e: globalThis.MouseEvent) => {
       // If the menu is open and the clicked target is not within the menu,
       // then close the menu
-      if (isDivFocused && ref.current && !ref.current.contains(e.target)) {
+      if (isDivFocused && ref.current && !ref.current.contains(e.target as HTMLElement)) {
         setIsDivFocused(false);
       }
     };
@@ -54,7 +55,7 @@ const HighlightInputForm = (): JSX.Element => {
         onClick={() => {
           setIsDivFocused(true);
         }}
-        className="bg-white p-2 flex border rounded-lg overflow-hidden flex-col gap-2 "
+        className="bg-white p-2 flex border rounded-lg text-sm overflow-hidden flex-col gap-2 "
       >
         <input
           value={title}
@@ -68,7 +69,7 @@ const HighlightInputForm = (): JSX.Element => {
           value={bodyText}
           onChange={(e) => handleTextAreaInputChange(e)}
           ref={textAreaRef}
-          className={`resize-none text-light-slate-11 mb-2 transition focus:outline-none rounded-lg ${
+          className={`resize-none font-normal text-light-slate-11 mb-2 transition focus:outline-none rounded-lg ${
             !isDivFocused ? "hidden" : ""
           }`}
         />

--- a/stories/molecules/highlight-input.stories.tsx
+++ b/stories/molecules/highlight-input.stories.tsx
@@ -1,0 +1,11 @@
+import { ComponentStory } from "@storybook/react";
+import HighlightInputForm from "components/molecules/HighlightInput/highlight-input-form";
+
+const storyConfig = {
+  title: "Design System/molecules/HighlightInputForm"
+};
+export default storyConfig;
+
+const HighlightInputTemplate: ComponentStory<typeof HighlightInputForm> = () => <HighlightInputForm />;
+
+export const Default = HighlightInputTemplate.bind({});


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR: 

- creates a new form UI to enable users post highlights of PRS
- Text area row is expandable with a limit of 5 (felt 5 is a good number of row before overflow scroll triggers)
- The post button is disabled until the `TextBody` has values in it

Note: 

> This is just UI for now, follow up issue will be opened for the implementation

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
Fixes #828
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<img width="637" alt="image" src="https://user-images.githubusercontent.com/62995161/217060668-a905e8ef-ae25-474d-a825-2fab06dd4e5c.png">


<img width="630" alt="image" src="https://user-images.githubusercontent.com/62995161/217060742-7528c65f-1614-4f2d-8adc-0c5beba3692e.png">

### Expandable input height
<img width="638" alt="image" src="https://user-images.githubusercontent.com/62995161/217060892-fef74844-21bc-4b76-8ca1-971c1062c74e.png">

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [x] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

