### PR TITLE
fix: disable create page button only if insight page name is empty

### DIFF
--- a/components/organisms/InsightPage/InsightPage.tsx
+++ b/components/organisms/InsightPage/InsightPage.tsx
@@ -69,15 +69,23 @@ const InsightPage = ({ edit, insight, pageRepos }: InsightPageProps) => {
     };
   });
 
+  const validateName = (name: string) => {
+    if (!name || name.trim().length <= 3) return false;
+
+    return true;
+  };
+
   const handleOnNameChange = (value: string) => {
-
     setName(value);
+    setIsNameValid(validateName(value));
+  };
 
-    if (!value || value.trim().length <= 3) setIsNameValid(false);
+  const disableCreateButton = () => {
+    if (insight?.name && validateName(name)) return false;
+    if (submitted) return true;
+    if (!isNameValid) return true;
 
-    if (value.trim().length > 3) {
-      setIsNameValid(true);
-    }
+    return false;
   };
 
   const handleCreateInsightPage = async () => {
@@ -279,7 +287,7 @@ const InsightPage = ({ edit, insight, pageRepos }: InsightPageProps) => {
           handleUpdatePage={handleUpdateInsightPage}
           handleAddToCart={handleReAddRepository}
           history={reposRemoved}
-          createPageButtonDisabled={submitted || !isNameValid}
+          createPageButtonDisabled={disableCreateButton()}
         >
           {repos.map((repo) => {
             const totalPrs =


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR fixes the issue where, when editing an insight page, the create page button is disabled even if the page name is there.
## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #892
## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
The cursor is not visible :sweat: 
[insights-page-bug.webm](https://user-images.githubusercontent.com/79809121/220359360-408f1652-3907-49f5-a522-a5f7d350bf8e.webm)


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

