### PR TITLE
fix: keep initial user settings data after being fetched

### DIFF
--- a/components/organisms/UserSettingsPage/user-settings-page.tsx
+++ b/components/organisms/UserSettingsPage/user-settings-page.tsx
@@ -28,7 +28,9 @@ type EmailPreferenceType = {
   receive_collaboration?: boolean;
 };
 const UserSettingsPage = ({ user }: userSettingsPageProps) => {
-  const { data: insightsUser } = useFetchUser(user?.user_metadata.user_name);
+  const { data: insightsUser } = useFetchUser(user?.user_metadata.user_name, {
+    revalidateOnFocus: false
+  });
 
   const [isValidEmail, setIsValidEmail] = useState<boolean>(true);
   const [displayLocalTime, setDisplayLocalTime] = useState(false);
@@ -48,7 +50,7 @@ const UserSettingsPage = ({ user }: userSettingsPageProps) => {
   useEffect(() => {
     async function fetchAuthSession() {
       const response = await authSession();
-      if (response !== false) {
+      if (response !== false && !userInfo) {
         setUserInfo(response);
         formRef.current!.nameInput.value = response.name;
         setEmail(response.email);

--- a/lib/hooks/useFetchUser.ts
+++ b/lib/hooks/useFetchUser.ts
@@ -1,11 +1,12 @@
 import publicApiFetcher from "lib/utils/public-api-fetcher";
-import useSWR, { Fetcher } from "swr";
+import useSWR, { Fetcher, SWRConfiguration } from "swr";
 
 export interface UserResponse extends DbUser {}
-const useFetchUser = (username: string) => {
+const useFetchUser = (username: string, config?: SWRConfiguration) => {
   const { data, error } = useSWR<UserResponse, Error>(
     username ? `users/${username}` : null,
-    publicApiFetcher as Fetcher<UserResponse, Error>
+    publicApiFetcher as Fetcher<UserResponse, Error>,
+    config
   );
 
   return {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR:
- Only stores the initial user profile settings in the form, and does not refresh when focusing the window again

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

Fixes #931 

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

