### PR TITLE
fix: center text inside upgrade access button

### DIFF
--- a/components/organisms/StripeCheckoutButton/stripe-checkout-button.tsx
+++ b/components/organisms/StripeCheckoutButton/stripe-checkout-button.tsx
@@ -37,7 +37,7 @@ const StripeCheckoutButton = () => {
 
       <p className="flex justify-center py-4 px-2">
         <form onSubmit={handleFormSubmit}>
-          <Button variant="primary" className="w-52 h-[38px]">
+          <Button variant="primary" className="w-52 h-[38px] flex justify-center">
             Upgrade Access
           </Button>
         </form>


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

Centers the  text inside the upgrade access button in the Reports page.

## Related Tickets & Documents
#1024 

## Mobile & Desktop Screenshots/Recordings
![image](https://user-images.githubusercontent.com/41837037/226049027-6f68f1cf-e539-4148-9d44-1c3a51ceaf48.png)



## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

