### PR TITLE
fix: insights hub layout inconsistencies on larger screens

### DIFF
--- a/layouts/hub-page.tsx
+++ b/layouts/hub-page.tsx
@@ -26,8 +26,8 @@ const HubPageLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <TopNav />
-      <div className="page-container flex min-h-[calc(100vh-(54px+95px))] flex-col items-center">
-        <div className="info-container w-full min-h-[100px]">
+      <div className="page-container flex min-h-[calc(100vh-(54px+95px))] bg-light-slate-3 flex-col items-center">
+        <div className="info-container container w-full min-h-[100px]">
           <Header>
             {insight ? (
               <InsightHeader insight={insight} repositories={repositories} insightId={insightId} isOwner={isOwner} />
@@ -47,7 +47,9 @@ const HubPageLayout = ({ children }: { children: React.ReactNode }) => {
           />
         </div>
 
-        <main className="flex w-full flex-1 flex-col items-center px-3 md:px-16 py-8 bg-light-slate-2">{children}</main>
+        <main className="flex w-full flex-1 flex-col  items-center px-3 md:px-16 py-8 bg-light-slate-2">
+          <div className="container mx-auto px-2 md:px-16">{children}</div>
+        </main>
       </div>
       <Footer />
     </>

--- a/layouts/hub.tsx
+++ b/layouts/hub.tsx
@@ -3,14 +3,13 @@ import React from "react";
 import Footer from "../components/organisms/Footer/footer";
 import TopNav from "../components/organisms/TopNav/top-nav";
 
-const HubLayout = ({children}: {children: React.ReactNode}) => {
-
+const HubLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <>
       <TopNav />
       <div className="page-container flex min-h-[calc(100vh-(54px+95px))] flex-col items-center">
         <main className="flex w-full flex-1 flex-col items-center px-3 md:px-16 py-8 bg-light-slate-2">
-          {children}
+          <div className="container mx-auto px-2 md:px-16">{children}</div>
         </main>
       </div>
       <Footer />


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR fixes the width issue of the insights layout on lager screen sizes
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
Fixes #1043 
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings


### Before 
![image](https://user-images.githubusercontent.com/62995161/227200581-08b62535-d7e9-485e-bde6-b700a5186e03.png)

### After
![image](https://user-images.githubusercontent.com/62995161/227200686-504cd101-7773-42b1-bba4-a3c217e61d16.png)


### Before
![image](https://user-images.githubusercontent.com/62995161/227201004-b717fd79-cf95-4b2e-b4e6-be73e5b1325c.png)

### After
![image](https://user-images.githubusercontent.com/62995161/227201114-c0e858fc-62b9-45dd-85d8-808e69f4105a.png)

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

