### PR TITLE
fix: adding regex pattern to validate twitter username input

### DIFF
--- a/components/organisms/UserSettingsPage/user-settings-page.tsx
+++ b/components/organisms/UserSettingsPage/user-settings-page.tsx
@@ -216,6 +216,7 @@ const UserSettingsPage = ({ user }: userSettingsPageProps) => {
               classNames="bg-light-slate-4 text-light-slate-11"
               placeholder="saucedopen"
               label="Twitter Username"
+              pattern="^\w{1,15}$"
               name="twitter_username"
             />
             <TextInput


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR fixes a bug caused by Twitter username input where entering the full Twitter URL caused an issue. Added a regex pattern to limit input to valid usernames with a maximum of 15 characters.

## Related Tickets & Documents

Fixes #1033 

## Mobile & Desktop Screenshots/Recordings

https://user-images.githubusercontent.com/113872927/228781123-9486e1fd-0ff8-46a4-af94-1635f690b337.mp4

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed