### PR TITLE
fix: show logo in the header for smaller screens

### DIFF
--- a/components/molecules/HeaderLogo/header-logo.tsx
+++ b/components/molecules/HeaderLogo/header-logo.tsx
@@ -20,9 +20,7 @@ const HeaderLogo: React.FC<HeaderLogoProps> = ({ textIsBlack, withBg = false }) 
           height={32}
           src={withBg ? openSaucedImgWithBg : openSaucedImg}
         />
-        <p className={`font-bold !text-base hidden xs:block ${textIsBlack ? "!text-black" : "!text-white"}`}>
-          OpenSauced
-        </p>
+        <p className={`font-bold !text-base ${textIsBlack ? "!text-black" : "!text-white"}`}>OpenSauced</p>
       </div>
     </Link>
   );


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert


## Description

#1063 decreased the size of the "Connect w/ GitHub" button for smaller screen, but also hid the OpenSauced Text Logo for below `xs` breakpoint.
This diff fixes that behavior and shows the logo even for smaller screens.

## Related Tickets & Documents

Fixes #1068

## Mobile & Desktop Screenshots/Recordings

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/55224033/228947933-89faf795-849a-4a7d-b8b1-fc4ce72d1610.png" height="500px" >
</td>
<td>
<img src="https://user-images.githubusercontent.com/55224033/228944699-010040bb-5822-45b1-9911-dbcc159fa188.png" height="500px" >
</td>
</tr>
</table>

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

- check CI is green and there are no visual defects in UI.


## [optional] What gif best describes this PR or how it makes you feel?

no gif for now ;) but here is my co-author:

# 🐼

