### PR TITLE
fix: user-setting-page breaks in ipad-mini

### DIFF
--- a/components/organisms/UserSettingsPage/user-settings-page.tsx
+++ b/components/organisms/UserSettingsPage/user-settings-page.tsx
@@ -165,7 +165,7 @@ const UserSettingsPage = ({ user }: userSettingsPageProps) => {
 
   return (
     <div className="container mx-auto md:px-16">
-      <div className="flex flex-col gap-4 text-sm md:flex-row md:gap-48 text-light-slate-11">
+      <div className="flex flex-col gap-4 text-sm md:flex-row md:gap-42 lg:gap-48 text-light-slate-11">
         <div>
           <Title className="!text-2xl !text-light-slate-11" level={2}>
             Public profile


### PR DESCRIPTION
changed  breakpoint for the gap between profile and intrests md:42 and lg:48 that seemed to fix it

fix #1128


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

changed  breakpoint for the gap between profile and intrests md:42 and lg:48 that seemed to fix it

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents

Fixes #1128 

## Mobile & Desktop Screenshots/Recordings
![image](https://user-images.githubusercontent.com/89102131/235159279-2657c9b4-1cd9-4561-aa01-b8da28056b4a.png)

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [X] 🙅 no documentation needed









<!-- note: PRs with deleted sections will be marked invalid -->

