### PR TITLE
fix: copy link button alignment

### DIFF
--- a/components/molecules/ContributorHighlight/contributor-highlight-card.tsx
+++ b/components/molecules/ContributorHighlight/contributor-highlight-card.tsx
@@ -245,16 +245,18 @@ const ContributorHighlightCard = ({
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onClick={() => handleCopyToClipboard(`${host}/feed/${id}`)}
-                  className="rounded-md flex gap-2.5 py-1 items-center pl-3 pr-7"
+                  className="rounded-md"
                 >
-                  <BsLink45Deg size={22} />
-                  <span>Copy link</span>
+                  <div className = "flex gap-2.5 py-1 items-center pl-3 pr-7 cursor-pointer">
+                    <BsLink45Deg size={22} />
+                    <span>Copy link</span>
+                  </div>
                 </DropdownMenuItem>
                 {loggedInUser ? (
                   <DropdownMenuItem
                     className={`rounded-md ${loggedInUser.user_metadata.user_name === user && "hidden"}`}
                   >
-                    <div onClick={isError ? follow : unFollow} className="flex gap-2.5 py-1  items-center pl-3 pr-7">
+                    <div onClick={isError ? follow : unFollow} className="flex gap-2.5 py-1 items-center pl-3 pr-7 cursor-pointer">
                       <FaUserPlus size={22} />
                       <span>
                         {!isError ? "Unfollow" : "Follow"} {user}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR fixes the bug #1078.
Container div element was missing, which caused the icon and the link to misalign.
cursor-pointer class were added to both Copy link and Follow user buttons

## Related Tickets & Documents
Fixes #1078

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
<img width="955" alt="missing-container" src="https://github.com/open-sauced/insights/assets/12442897/b2a8c5ed-a1c3-4bfb-98cb-4dc7b148b765">


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

