### PR TITLE
fix: pagination medium screens

### DIFF
--- a/components/molecules/Pagination/pagination.tsx
+++ b/components/molecules/Pagination/pagination.tsx
@@ -44,7 +44,7 @@ const Pagination = ({
 
   return (
     <>
-      <div className=" w-max flex gap-x-4 items-center ">
+      <div className="w-max flex gap-x-4 items-center">
         <div className="flex items-center gap-x-4">
           <button
             className="text-light-slate-9 disabled:text-light-slate-7"
@@ -82,7 +82,8 @@ const Pagination = ({
         <div
           className={`${divisor && "md:border-r-2 border-r-light-slate-6"} text-sm text-light-slate-9    py-1 md:pr-4`}
         >
-          Total {totalPage > 999 ? humanizeNumber(totalPage, null) : totalPage} pages
+          Total {totalPage > 999 ? humanizeNumber(totalPage, null) : totalPage} 
+          <span className="md:invisible lg:visible"> pages </span>
         </div>
         {goToPage && (
           <div className="hidden md:block">

--- a/components/molecules/PaginationGotoPage/pagination-goto-page.tsx
+++ b/components/molecules/PaginationGotoPage/pagination-goto-page.tsx
@@ -41,7 +41,7 @@ const PaginationGotoPage = ({ page, name, setPage, totalPage }: PaginationGotoPa
         className="min-w-4 w-10 text-center text-sm text-light-slate-10 focus:outline-none border rounded-lg py-1 px-2"
       />
       <button
-        className="text-light-orange-10 text-sm px-4 py-1.5 rounded-lg hover:bg-orange-100 bg-light-orange-3"
+        className="text-light-orange-10 text-sm px-2 py-1.5 rounded-lg hover:bg-orange-100 bg-light-orange-3"
         type="submit"
       >
         Go to page

--- a/components/molecules/PaginationResults/pagination-result.tsx
+++ b/components/molecules/PaginationResults/pagination-result.tsx
@@ -19,10 +19,10 @@ const PaginationResults = ({ metaInfo, entity, total, className }: PaginationRes
       ? metaInfo.page * metaInfo.limit
       : metaInfo.itemCount;
   return (
-    <div className={`${className && className} flex items-center gap-x-1   text-sm text-light-slate-9 tracking-tight`}>
-      <span className="hidden md:block">Showing</span> <span className="text-light-slate-12">{from} -</span>
+    <div className={`${className && className} md:inline-block items-center gap-x-1   text-sm text-light-slate-9 tracking-tight`}>
+      <span className="hidden md:inline-block">Showing</span> <span className="text-light-slate-12">{from} -</span>
       <span className="text-light-slate-12">{to}</span> of {total > 999 ? humanizeNumber(total, null) : total}
-      <span>{entity}</span>
+      <span> {entity}</span>
     </div>
   );
 };

--- a/components/molecules/PaginationResults/pagination-result.tsx
+++ b/components/molecules/PaginationResults/pagination-result.tsx
@@ -19,10 +19,11 @@ const PaginationResults = ({ metaInfo, entity, total, className }: PaginationRes
       ? metaInfo.page * metaInfo.limit
       : metaInfo.itemCount;
   return (
-    <div className={`${className && className} md:inline-block items-center gap-x-1   text-sm text-light-slate-9 tracking-tight`}>
+    <div className={`${className ? className : ""} md:inline-block items-center gap-x-1   text-sm text-light-slate-9 tracking-tight`}>
       <span className="hidden md:inline-block">Showing</span> <span className="text-light-slate-12">{from} -</span>
       <span className="text-light-slate-12">{to}</span> of {total > 999 ? humanizeNumber(total, null) : total}
-      <span> {entity}</span>
+      {/* hide on medium screens */}
+      <span className="md:invisible lg:visible"> {entity}</span>
     </div>
   );
 };

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -196,7 +196,7 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
             <HomeHighlightsWrapper emojis={emojis} mutate={mutate} highlights={data} loading={isLoading} />
             {meta.pageCount > 1 && (
               <div className="mt-10 max-w-[48rem] flex px-2 items-center justify-between">
-                <div>
+              <div className="w-max flex gap-x-4 items-center">
                   <PaginationResults metaInfo={meta} total={meta.itemCount} entity={"highlights"} />
                 </div>
                 <Pagination

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -196,7 +196,7 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
             <HomeHighlightsWrapper emojis={emojis} mutate={mutate} highlights={data} loading={isLoading} />
             {meta.pageCount > 1 && (
               <div className="mt-10 max-w-[48rem] flex px-2 items-center justify-between">
-              <div className="w-max flex gap-x-4 items-center">
+                <div className="w-max flex gap-x-4 items-center">
                   <PaginationResults metaInfo={meta} total={meta.itemCount} entity={"highlights"} />
                 </div>
                 <Pagination


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
Refactor PaginationResults component to display entity count for better readability and user experience. The component UI has been modified to adjust for smaller screens by replacing "block" with "inline-block". The "md:block" class has been changed to "md:inline-block" to maintain visual consistency. The entity count is now displayed with a space before it for improved readability.

_description created by [OpenSauced](https://opensauced-ai.netlify.app/)_

Fixes #1131 

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

Before:
![image](https://github.com/open-sauced/insights/assets/18273833/5b30f018-fc5e-462f-a752-b3e732d7c525)

After:
![image](https://github.com/open-sauced/insights/assets/18273833/49e48ad1-ce5e-4c2f-8f89-0d12551974bc)


<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

