### PR TITLE
feat: hide chatbot on non-prod environment and mobile screens

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -56,6 +56,9 @@ function MyApp({ Component, pageProps }: ComponentWithPageLayout) {
   if (typeof window !== "undefined")
     hostname = window.location.hostname;
 
+  // JUST CHECKING WHAT THE HOSNAME WILL BE ON DEPLOY PREVIEW 😅
+  console.log({hostname});
+
   useEffect(() => {
     const chatWidget = document.getElementById("sitegpt-chat-icon");
     if (chatWidget) {
@@ -65,7 +68,7 @@ function MyApp({ Component, pageProps }: ComponentWithPageLayout) {
         chatWidget.style.display = "block";
       }
     }
-  },[isMobile, hostname, process.env.NODE_ENV]);
+  },[isMobile, hostname]);
 
   useEffect(() => {
     updateSEO(Component.SEO || {});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -52,16 +52,20 @@ function MyApp({ Component, pageProps }: ComponentWithPageLayout) {
 
   const isMobile = useMediaQuery("(max-width:720px)");
 
+  let hostname = "";
+  if (typeof window !== "undefined")
+    hostname = window.location.hostname;
+
   useEffect(() => {
     const chatWidget = document.getElementById("sitegpt-chat-icon");
     if (chatWidget) {
-      if (isMobile || process.env.NODE_ENV !== "production") {
+      if (isMobile || process.env.NODE_ENV !== "production" || hostname !== "insights.opensauced.pizza") {
         chatWidget.style.display = "none";
       } else {
         chatWidget.style.display = "block";
       }
     }
-  },[isMobile]);
+  },[isMobile, hostname, process.env.NODE_ENV]);
 
   useEffect(() => {
     updateSEO(Component.SEO || {});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -51,24 +51,28 @@ function MyApp({ Component, pageProps }: ComponentWithPageLayout) {
   Component.updateSEO = updateSEO;
 
   const isMobile = useMediaQuery("(max-width:720px)");
-
   let hostname = "";
+
   if (typeof window !== "undefined")
     hostname = window.location.hostname;
 
-  // JUST CHECKING WHAT THE HOSNAME WILL BE ON DEPLOY PREVIEW 😅
-  console.log({hostname});
-
   useEffect(() => {
-    const chatWidget = document.getElementById("sitegpt-chat-icon");
-    if (chatWidget) {
-      if (isMobile || process.env.NODE_ENV !== "production" || hostname !== "insights.opensauced.pizza") {
-        chatWidget.style.display = "none";
-      } else {
-        chatWidget.style.display = "block";
+    let chatButton = document.getElementById("sitegpt-chat-icon");
+
+    const interval = setInterval(() => {
+      chatButton = document.getElementById("sitegpt-chat-icon");
+      if (chatButton) {
+        if (hostname !== "insights.opensauced.pizza" || isMobile) {
+          chatButton.style.display = "none";
+        } else {
+          chatButton.style.display = "block";
+        }
+        clearInterval(interval);
       }
-    }
-  },[isMobile, hostname]);
+    }, 500);
+
+    return () => clearInterval(interval);
+  },[hostname, isMobile, router.isReady]);
 
   useEffect(() => {
     updateSEO(Component.SEO || {});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,7 +23,6 @@ import useSession from "lib/hooks/useSession";
 
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
-import { useMediaQuery } from "lib/hooks/useMediaQuery";
 
 // Check that PostHog is client-side (used to handle Next.js SSR)
 if (typeof window !== "undefined") {
@@ -50,7 +49,6 @@ function MyApp({ Component, pageProps }: ComponentWithPageLayout) {
   const [seo, updateSEO] = useState<SEOobject>(Component.SEO || {});
   Component.updateSEO = updateSEO;
 
-  const isMobile = useMediaQuery("(max-width:720px)");
   let hostname = "";
 
   if (typeof window !== "undefined")
@@ -62,7 +60,7 @@ function MyApp({ Component, pageProps }: ComponentWithPageLayout) {
     const interval = setInterval(() => {
       chatButton = document.getElementById("sitegpt-chat-icon");
       if (chatButton) {
-        if (hostname !== "insights.opensauced.pizza" || isMobile) {
+        if (hostname !== "insights.opensauced.pizza") {
           chatButton.style.display = "none";
         } else {
           chatButton.style.display = "block";
@@ -72,7 +70,7 @@ function MyApp({ Component, pageProps }: ComponentWithPageLayout) {
     }, 500);
 
     return () => clearInterval(interval);
-  },[hostname, isMobile, router.isReady]);
+  },[hostname, router.isReady]);
 
   useEffect(() => {
     updateSEO(Component.SEO || {});

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -23,6 +23,7 @@ import useSession from "lib/hooks/useSession";
 
 import posthog from "posthog-js";
 import { PostHogProvider } from "posthog-js/react";
+import { useMediaQuery } from "lib/hooks/useMediaQuery";
 
 // Check that PostHog is client-side (used to handle Next.js SSR)
 if (typeof window !== "undefined") {
@@ -49,6 +50,19 @@ function MyApp({ Component, pageProps }: ComponentWithPageLayout) {
   const [seo, updateSEO] = useState<SEOobject>(Component.SEO || {});
   Component.updateSEO = updateSEO;
 
+  const isMobile = useMediaQuery("(max-width:720px)");
+
+  useEffect(() => {
+    const chatWidget = document.getElementById("sitegpt-chat-icon");
+    if (chatWidget) {
+      if (isMobile || process.env.NODE_ENV !== "production") {
+        chatWidget.style.display = "none";
+      } else {
+        chatWidget.style.display = "block";
+      }
+    }
+  },[isMobile]);
+
   useEffect(() => {
     updateSEO(Component.SEO || {});
   }, [Component]);
@@ -74,8 +88,6 @@ function MyApp({ Component, pageProps }: ComponentWithPageLayout) {
       router.events.off("routeChangeComplete", handleRouteChange);
     };
   }, []);
-
-  const { filterName, toolName } = router.query;
 
   function localStorageProvider() {
     if (typeof window !== "undefined") {


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR hides the chatbot on non-production environments and on mobile screens.

> **Note**

```tsx
{!isMobile || NODE_ENV === 'production' || hostname === 'insights.opensauced.pizza' && (
  <Script id="siteGPT" type="text/javascript">
    ..
  </Script>
```

The code above won't work because:
- if you visit the app on desktop (first load), the chatbot will be there but won't go away when you switch on mobile (using devtools)
- if you visit the app on mobile (first load), the chatbot will be hidden and when you expand to desktop, it will show up. But if you go back to mobile, it will still be there.

The reason why that's happening is that, when the `script` is rendered, it will inject a button in the DOM, so even if you change the view to mobile and the script is hidden (like the code above), that won't help because the button is still in the DOM.

> **Note**

I have added an interval in the `useEffect` to check if the button is in the DOM because sometimes the script injects the chat button in the DOM after the first render.
## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #1217
## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
![hide-chatbot](https://github.com/open-sauced/insights/assets/79809121/3a1881f5-291e-4ba2-ba8a-d31c56018d32)


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

