### PR TITLE
feat: handle close highlight dialog

### DIFF
--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -46,6 +46,8 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
   const { id } = router.query;
   const singleHighlight = props.highlight;
   const highlightId = props.highlight?.id as string;
+  console.log({highlightId, id});
+  console.log("RENDERING...");
 
   const { data: followersRepo } = useFetchFollowersHighlightRepos();
 
@@ -75,16 +77,16 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
       router.push(`/feed?repo=${selectedRepo}`);
       setPage(1);
     }
-    if (highlightId) {
+    if (id) {
       setOpenSingleHighlight(true);
       router.push(`/feed/${id}`);
     }
 
-    if (!selectedRepo && !highlightId) {
+    if (!selectedRepo && !id) {
       router.push("/feed");
       setPage(1);
     }
-  }, [selectedRepo, highlightId]);
+  }, [selectedRepo, id]);
 
   useEffect(() => {
     setHydrated(true);
@@ -116,6 +118,7 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
             open={openSingleHighlight}
             onOpenChange={(open) => {
               if (!open) {
+                setOpenSingleHighlight(false);
                 router.push("/feed");
               }
             }}

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -46,8 +46,6 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
   const { id } = router.query;
   const singleHighlight = props.highlight;
   const highlightId = props.highlight?.id as string;
-  console.log({highlightId, id});
-  console.log("RENDERING...");
 
   const { data: followersRepo } = useFetchFollowersHighlightRepos();
 


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR fixes a bug where the single highlight dialog was not being closed after clicking the close button or the overlay. The `setOpenSingleHighlight` state is now properly updated when the highlight modal is closed.

_Generated using [OpenSauced](https://opensauced.ai/)._
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #1267 
## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
Before

https://github.com/open-sauced/insights/assets/79809121/9b07f50a-6918-4016-be86-376efe8ac3d5

After


https://github.com/open-sauced/insights/assets/79809121/758f4fdd-9109-4037-a591-25f5515f2c8f



## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

