### PR TITLE
fix: linked single highlight dialog's contributor info div to contributor profile

### DIFF
--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Link from "next/link";
 import formatDistanceToNowStrict from "date-fns/formatDistanceToNowStrict";
 import clsx from "clsx";
 
@@ -125,13 +126,15 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
               <div className="flex flex-col gap-8 mx-auto mt-10">
                 <div className="flex flex-col gap-6 px-3 ">
                   <div className="flex items-center gap-3 ">
-                    <Avatar
-                      alt="user profile avatar"
-                      isCircle
-                      size="sm"
-                      avatarURL={`https://www.github.com/${singleHighlight.login}.png?size=300`}
-                    />
-                    <strong>{singleHighlight.login}</strong>
+                    <Link href={`/user/${singleHighlight.login}`} className="flex items-center gap-3">
+                      <Avatar
+                        alt="user profile avatar"
+                        isCircle
+                        size="sm"
+                        avatarURL={`https://www.github.com/${singleHighlight.login}.png?size=300`}
+                      />
+                      <strong>{singleHighlight.login}</strong>
+                    </Link>
                     <span className="text-xs font-normal text-light-slate-11">
                       {formatDistanceToNowStrict(new Date(singleHighlight.created_at), {
                         addSuffix: true,


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/open-sauced/blob/HEAD/CONTRIBUTING.md#create-a-pull-request.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/open-sauced/blob/HEAD/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description
This PR Links the Contributor Info `div` (which contains the contributor's `Avatar` component and **login/username**) on the single highlight `Dialog` component to the contributor's profile on route `/user/[username]`
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
Code Sample

```javascript
// pages\feed\index.tsx

<Link href={`/user/${singleHighlight.login}`} className="flex items-center gap-3">
  <Avatar
    alt="user profile avatar"
    isCircle
    size="sm"
    avatarURL={`https://www.github.com/${singleHighlight.login}.png?size=300`}
  />
  <strong>{singleHighlight.login}</strong>
</Link>
```


## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #1276 

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
**Before** 
https://github-production-user-asset-6210df.s3.amazonaws.com/25631971/246900915-847f8e76-4f74-4b39-b113-6a0e6cdb3dc6.webm

**After**
https://github-production-user-asset-6210df.s3.amazonaws.com/25631971/246901000-f1e27d4e-e1fe-4b33-bb05-04c3a71df804.webm


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
None


## [optional] What gif best describes this PR or how it makes you feel?
🙏


<!-- note: PRs with deleted sections will be marked invalid -->

