### PR TITLE
fix: properly format local time displayed on user's profile

### DIFF
--- a/lib/utils/timezones.ts
+++ b/lib/utils/timezones.ts
@@ -1200,5 +1200,6 @@ export const getTimeByTimezone = (offset: number) => {
   // using supplied offset
   const time = new Date(utc + 3600000 * offset);
 
+  // The formatted time in the specified timezone
   return format(time, "hh:mmaaa");
 };

--- a/lib/utils/timezones.ts
+++ b/lib/utils/timezones.ts
@@ -1198,5 +1198,5 @@ export const getTimeByTimezone = (offset: number) => {
   // using supplied offset
   const time = new Date(utc + 3600000 * offset);
 
-  return `${time.getHours()}:${time.getMinutes()}${time.getHours() > 11 ? "pm" : "am"}`;
+  return `${time.getHours()}:${`0${time.getMinutes()}`.slice(-2)}${time.getHours() > 11 ? "pm" : "am"}`;
 };

--- a/lib/utils/timezones.ts
+++ b/lib/utils/timezones.ts
@@ -1,3 +1,5 @@
+import { format } from "date-fns";
+
 export const timezones = [
   {
     value: "Dateline Standard Time",
@@ -1198,5 +1200,5 @@ export const getTimeByTimezone = (offset: number) => {
   // using supplied offset
   const time = new Date(utc + 3600000 * offset);
 
-  return `${time.getHours()}:${`0${time.getMinutes()}`.slice(-2)}${time.getHours() > 11 ? "pm" : "am"}`;
+  return format(time, "hh:mmaaa");
 };


### PR DESCRIPTION
"fix #1275"

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR fixes the issue related to local time formatting on the user's profile, the local time is properly formatted on the user's profile. If the minutes are less than 10, then a leading zero will be displayed and time will be properly displayed in 12 hours format.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

Fixes #1275

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->

<img width="473" alt="Screenshot 2023-06-22 at 11 00 43 AM" src="https://github.com/open-sauced/insights/assets/67257981/f5c49e0a-a4b1-4318-8417-ef6d714d535b">

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

