### PR TITLE
feat:  hide highlights tab components on profiles without highlights

### DIFF
--- a/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
+++ b/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
@@ -140,6 +140,7 @@ const ContributorProfileTab = ({
               "data-[state=active]:border-sauced-orange shrink-0 data-[state=active]:border-b-2 text-2xl",
               tab === "Recommendations" &&
                 "font-bold text-transparent bg-clip-text bg-gradient-to-r from-[#EA4600] to-[#EB9B00]",
+              user?.user_metadata.user_name !== login && !hasHighlights && tab === "Highlights" && "hidden",
               user && user.user_metadata.user_name !== login && tab === "Recommendations" && "hidden",
               user && user.user_metadata.user_name !== login && tab === "Requests" && "hidden",
               !user && tab === "Recommendations" && "hidden",
@@ -155,105 +156,107 @@ const ContributorProfileTab = ({
 
       {/* Highlights Tab details */}
 
-      <TabsContent value="Highlights">
-        {inputVisible && user?.user_metadata.user_name === login && (
-          <div className="lg:pl-20 lg:gap-x-3 pt-4 flex max-w-[48rem]">
-            <div className="hidden lg:inline-flex">
-              <Avatar
-                alt="user profile avatar"
-                size="sm"
-                avatarURL={`https://www.github.com/${githubName}.png?size=300`}
-              />
+      {(user?.user_metadata.user_name === login || hasHighlights) && (
+        <TabsContent value="Highlights">
+          {inputVisible && user?.user_metadata.user_name === login && (
+            <div className="lg:pl-20 lg:gap-x-3 pt-4 flex max-w-[48rem]">
+              <div className="hidden lg:inline-flex">
+                <Avatar
+                  alt="user profile avatar"
+                  size="sm"
+                  avatarURL={`https://www.github.com/${githubName}.png?size=300`}
+                />
+              </div>
+
+              <HighlightInputForm refreshCallback={mutate} />
             </div>
-
-            <HighlightInputForm refreshCallback={mutate} />
-          </div>
-        )}
-        <div className="flex flex-col gap-8 mt-8">
-          {/* <HightlightEmptyState /> */}
-
-          {isError && <>An error occured</>}
-          {isLoading && (
-            <>
-              {Array.from({ length: 2 }).map((_, index) => (
-                <div className="flex flex-col gap-2 lg:flex-row lg:gap-6" key={index}>
-                  <SkeletonWrapper width={100} height={20} />
-                  <div className="md:max-w-[40rem]">
-                    <SkeletonWrapper height={20} width={500} classNames="mb-2" />
-                    <SkeletonWrapper height={300} />
-                  </div>
-                </div>
-              ))}
-            </>
           )}
-          <>
-            {!isError && highlights && highlights.length > 0 ? (
-              <div>
-                {highlights.map(({ id, title, highlight, url, shipped_at, created_at }) => (
-                  <div className="flex flex-col gap-2 mb-6 lg:flex-row lg:gap-7" key={id}>
-                    <Link href={`/feed/${id}`}>
-                      <p className="text-sm text-light-slate-10">
-                        {formatDistanceToNowStrict(new Date(created_at), { addSuffix: true })}
-                      </p>
-                    </Link>
-                    <ContributorHighlightCard
-                      emojis={emojis}
-                      id={id}
-                      user={login || ""}
-                      title={title}
-                      desc={highlight}
-                      prLink={url}
-                      shipped_date={shipped_at}
-                      refreshCallBack={mutate}
-                    />
+          <div className="flex flex-col gap-8 mt-8">
+            {/* <HightlightEmptyState /> */}
+
+            {isError && <>An error occured</>}
+            {isLoading && (
+              <>
+                {Array.from({ length: 2 }).map((_, index) => (
+                  <div className="flex flex-col gap-2 lg:flex-row lg:gap-6" key={index}>
+                    <SkeletonWrapper width={100} height={20} />
+                    <div className="md:max-w-[40rem]">
+                      <SkeletonWrapper height={20} width={500} classNames="mb-2" />
+                      <SkeletonWrapper height={300} />
+                    </div>
                   </div>
                 ))}
-                {meta.pageCount > 1 && (
-                  <div className="mt-10 max-w-[48rem] flex px-2 items-center justify-between">
-                    <div>
-                      <PaginationResults metaInfo={meta} total={meta.itemCount} entity={"highlights"} />
+              </>
+            )}
+            <>
+              {!isError && highlights && highlights.length > 0 ? (
+                <div>
+                  {highlights.map(({ id, title, highlight, url, shipped_at, created_at }) => (
+                    <div className="flex flex-col gap-2 mb-6 lg:flex-row lg:gap-7" key={id}>
+                      <Link href={`/feed/${id}`}>
+                        <p className="text-sm text-light-slate-10">
+                          {formatDistanceToNowStrict(new Date(created_at), { addSuffix: true })}
+                        </p>
+                      </Link>
+                      <ContributorHighlightCard
+                        emojis={emojis}
+                        id={id}
+                        user={login || ""}
+                        title={title}
+                        desc={highlight}
+                        prLink={url}
+                        shipped_date={shipped_at}
+                        refreshCallBack={mutate}
+                      />
                     </div>
-                    <Pagination
-                      pages={[]}
-                      totalPage={meta.pageCount}
-                      page={meta.page}
-                      pageSize={meta.itemCount}
-                      goToPage
-                      hasNextPage={meta.hasNextPage}
-                      hasPreviousPage={meta.hasPreviousPage}
-                      onPageChange={function (page: number): void {
-                        setPage(page);
-                      }}
-                    />
-                  </div>
-                )}
-              </div>
-            ) : (
-              <DashContainer>
-                <div className="text-center">
-                  {user?.user_metadata.user_name === login ? (
-                    <>
-                      <p>
-                        You don&apos;t have any highlights yet! <br /> Highlights are a great way to show off your
-                        contributions. Merge any pull requests recently?
-                      </p>
-                      {!inputVisible && (
-                        <Button onClick={() => setInputVisible(true)} className="mt-5" variant="primary">
-                          Add a highlight
-                        </Button>
-                      )}
-                    </>
-                  ) : (
-                    <>
-                      <p>{` ${login} hasn't posted any highlights yet!`}</p>
-                    </>
+                  ))}
+                  {meta.pageCount > 1 && (
+                    <div className="mt-10 max-w-[48rem] flex px-2 items-center justify-between">
+                      <div>
+                        <PaginationResults metaInfo={meta} total={meta.itemCount} entity={"highlights"} />
+                      </div>
+                      <Pagination
+                        pages={[]}
+                        totalPage={meta.pageCount}
+                        page={meta.page}
+                        pageSize={meta.itemCount}
+                        goToPage
+                        hasNextPage={meta.hasNextPage}
+                        hasPreviousPage={meta.hasPreviousPage}
+                        onPageChange={function (page: number): void {
+                          setPage(page);
+                        }}
+                      />
+                    </div>
                   )}
                 </div>
-              </DashContainer>
-            )}
-          </>
-        </div>
-      </TabsContent>
+              ) : (
+                <DashContainer>
+                  <div className="text-center">
+                    {user?.user_metadata.user_name === login ? (
+                      <>
+                        <p>
+                          You don&apos;t have any highlights yet! <br /> Highlights are a great way to show off your
+                          contributions. Merge any pull requests recently?
+                        </p>
+                        {!inputVisible && (
+                          <Button onClick={() => setInputVisible(true)} className="mt-5" variant="primary">
+                            Add a highlight
+                          </Button>
+                        )}
+                      </>
+                    ) : (
+                      <>
+                        <p>{` ${login} hasn't posted any highlights yet!`}</p>
+                      </>
+                    )}
+                  </div>
+                </DashContainer>
+              )}
+            </>
+          </div>
+        </TabsContent>
+      )}
 
       {/* Contributions Tab Details */}
 

--- a/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
+++ b/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
@@ -232,23 +232,15 @@ const ContributorProfileTab = ({
                 </div>
               ) : (
                 <DashContainer>
-                  <div className="text-center">
-                    {user?.user_metadata.user_name === login ? (
-                      <>
-                        <p>
-                          You don&apos;t have any highlights yet! <br /> Highlights are a great way to show off your
-                          contributions. Merge any pull requests recently?
-                        </p>
-                        {!inputVisible && (
-                          <Button onClick={() => setInputVisible(true)} className="mt-5" variant="primary">
-                            Add a highlight
-                          </Button>
-                        )}
-                      </>
-                    ) : (
-                      <>
-                        <p>{` ${login} hasn't posted any highlights yet!`}</p>
-                      </>
+                  <div className="text-center"> 
+                    <p>
+                      You don&apos;t have any highlights yet! <br /> Highlights are a great way to show off your
+                      contributions. Merge any pull requests recently?
+                    </p>
+                    {!inputVisible && (
+                      <Button onClick={() => setInputVisible(true)} className="mt-5" variant="primary">
+                        Add a highlight
+                      </Button>
                     )}
                   </div>
                 </DashContainer>


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR implements the ability to Hide Highlight Tabs Content and Trigger components for user Profiles that either haven't connected their GitHub or most notably haven't posted any highlights.

This was done by conditionally rendering the `hidden` utility class on the `TabsTrigger` component item. 

```javascript
<TabsTrigger
  key={tab}
  className={clsx(
    ...
    user?.user_metadata.user_name !== login && !hasHighlights && tab === "Highlights" && "hidden",
    ...
  )}
  value={tab}
>
  ...
</TabsTrigger>
```

...and conditionally rendering its associated `TabsContent` component

```javascript
{(user?.user_metadata.user_name === login || hasHighlights) && (
  <TabsContent>
    ...
  </TabsContent>
)}
```

I also address the case where currently logged in user has no highlights, ensuring the Highlight Tab Components are rendered/displayed in the case where they are on their own profile. Screenshots of different cases below.

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
fixes #1227 

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
**Profile with Highlights**

![screenshot-localhost_3000-2023 06 27-18_02_52](https://github.com/open-sauced/insights/assets/25631971/b87fee40-3e39-41aa-bd66-54cd6014f805)

**Profile without Highlights**

![screenshot-localhost_3000-2023 06 27-18_02_42](https://github.com/open-sauced/insights/assets/25631971/43649064-0e0e-40ff-8729-4a2ef55e33b3)

**Currently Logged In User Profile without Highlights**

![screenshot-localhost_3000-2023 06 27-18_03_04](https://github.com/open-sauced/insights/assets/25631971/fa431901-8965-48ed-b385-eca0e99f27c9)

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
None


## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

