### PR TITLE
chore: Add import related eslint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,26 @@
 {
   "extends": ["next/core-web-vitals", "prettier"],
+  "plugins": ["unused-imports"],
   "rules": {
     "quotes": "error",
     "jsx-quotes": "error",
     "semi": "error",
-    "indent": ["error", 2]
+    "indent": ["error", 2],
+    "unused-imports/no-unused-imports": "error",
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "object",
+          "type",
+          "index",
+          "parent",
+          "sibling"
+        ]
+      }
+    ]
   }
 }

--- a/components/atoms/Avatar/avatar-hover-card.tsx
+++ b/components/atoms/Avatar/avatar-hover-card.tsx
@@ -2,10 +2,10 @@
 import * as HoverCard from "@radix-ui/react-hover-card";
 import Link from "next/link";
 
+import Image from "next/image";
 import HoverCardWrapper from "components/molecules/HoverCardWrapper/hover-card-wrapper";
 
 import { getAvatarByUsername } from "lib/utils/github";
-import Image from "next/image";
 
 declare interface AvatarProps {
   contributor: string;

--- a/components/atoms/Avatar/avatar.tsx
+++ b/components/atoms/Avatar/avatar.tsx
@@ -1,5 +1,4 @@
 import Image, { StaticImageData } from "next/image";
-import AvatarImage from "../../../img/hacktoberfest-icon.png";
 import cachedImage from "lib/utils/cachedImages";
 
 interface AvatarProps {

--- a/components/atoms/ContextFilterButton/context-filter-button.tsx
+++ b/components/atoms/ContextFilterButton/context-filter-button.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import Text from "../Typography/text";
 import { FiPlus } from "react-icons/fi";
+import Text from "../Typography/text";
 interface ContextFilterButtonProps {
   className?: string;
   children?: React.ReactNode;

--- a/components/atoms/Error/Error.tsx
+++ b/components/atoms/Error/Error.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import clsx from "clsx";
 import Text from "@supabase/ui/dist/cjs/components/Typography/Text";
-import Icon from "../Icon/icon";
 import ErrorIcon from "img/errorIcon.svg";
+import Icon from "../Icon/icon";
 
 interface ErrorProps {
   errorMessage?: string;

--- a/components/atoms/LayoutToggle/layout-toggle.tsx
+++ b/components/atoms/LayoutToggle/layout-toggle.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 
 import { BsListUl } from "react-icons/bs";
 import { BiGridAlt } from "react-icons/bi";

--- a/components/atoms/PillSelector/pill-selector.tsx
+++ b/components/atoms/PillSelector/pill-selector.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
-import Icon from "../Icon/icon";
 import cancelIcon from "img/x-circle.svg";
+import Icon from "../Icon/icon";
 
 interface PillSelectorButtonProps {
   className?: string;

--- a/components/atoms/Select/limit-select.tsx
+++ b/components/atoms/Select/limit-select.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "components/atoms/Select/select";
 import clsx from "clsx";
 import { RiArrowUpSLine, RiArrowDownSLine } from "react-icons/ri";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "components/atoms/Select/select";
 
 interface LimitSelectProps {
   placeholder: string;

--- a/components/atoms/ToggleOption/toggle-option.tsx
+++ b/components/atoms/ToggleOption/toggle-option.tsx
@@ -1,5 +1,5 @@
-import ToggleSwitch from "../ToggleSwitch/toggle-switch";
 import { HiInformationCircle } from "react-icons/hi";
+import ToggleSwitch from "../ToggleSwitch/toggle-switch";
 interface ToogleOptionProps {
   optionText: string;
   withIcon?: boolean;

--- a/components/atoms/TopUserCard/top-user-card.tsx
+++ b/components/atoms/TopUserCard/top-user-card.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import Avatar from "../Avatar/avatar";
 import { getAvatarByUsername } from "lib/utils/github";
+import Avatar from "../Avatar/avatar";
 import Button from "../Button/button";
 
 export interface TopUserCardProps {

--- a/components/atoms/UserCard/user-card.tsx
+++ b/components/atoms/UserCard/user-card.tsx
@@ -1,6 +1,6 @@
-import { getAvatarByUsername } from "lib/utils/github";
 import Image from "next/image";
 import React from "react";
+import { getAvatarByUsername } from "lib/utils/github";
 
 type MetaObj = {
   name: "Followers" | "Following" | "Highlights";

--- a/components/molecules/AuthSection/auth-section.tsx
+++ b/components/molecules/AuthSection/auth-section.tsx
@@ -8,23 +8,23 @@ import { FiLogOut, FiSettings } from "react-icons/fi";
 import { Divider } from "@supabase/ui";
 
 import useSession from "lib/hooks/useSession";
-import useSupabaseAuth from "../../../lib/hooks/useSupabaseAuth";
 
 import PersonIcon from "img/icons/person-icon.svg";
 
-import downArrow from "../../../img/chevron-down.svg";
 import Avatar from "components/atoms/Avatar/avatar";
 import Button from "components/atoms/Button/button";
-import userAvatar from "../../../img/ellipse-1.png";
-import OnboardingButton from "../OnboardingButton/onboarding-button";
-import DropdownList from "../DropdownList/dropdown-list";
 import Text from "components/atoms/Typography/text";
 import GitHubIcon from "img/icons/github-icon.svg";
 import Icon from "components/atoms/Icon/icon";
-import { Popover, PopoverContent, PopoverTrigger } from "../Popover/popover";
 import NotificationCard from "components/atoms/NotificationsCard/notification-card";
 import { authSession } from "lib/hooks/authSession";
 import { Spinner } from "components/atoms/SpinLoader/spin-loader";
+import { Popover, PopoverContent, PopoverTrigger } from "../Popover/popover";
+import DropdownList from "../DropdownList/dropdown-list";
+import OnboardingButton from "../OnboardingButton/onboarding-button";
+import userAvatar from "../../../img/ellipse-1.png";
+import downArrow from "../../../img/chevron-down.svg";
+import useSupabaseAuth from "../../../lib/hooks/useSupabaseAuth";
 
 const AuthSection: React.FC = ({}) => {
   const router = useRouter();

--- a/components/molecules/Billboard/billboard.tsx
+++ b/components/molecules/Billboard/billboard.tsx
@@ -1,6 +1,4 @@
 import * as AspectRatio from "@radix-ui/react-aspect-ratio";
-import Button from "components/atoms/Button/button";
-import Image from "next/image";
 import React from "react";
 
 interface BillBoardProps {

--- a/components/molecules/CardHorizontalBarChart/card-horizontal-bar-chart.tsx
+++ b/components/molecules/CardHorizontalBarChart/card-horizontal-bar-chart.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import Text from "components/atoms/Typography/text";
-import colors from "../../../lib/utils/color.json";
 import Tooltip from "components/atoms/Tooltip/tooltip";
+import colors from "../../../lib/utils/color.json";
 
 export interface AllSimpleColors {
   [key: string]: {

--- a/components/molecules/CardRepoList/card-repo-list.tsx
+++ b/components/molecules/CardRepoList/card-repo-list.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
+import { StaticImageData } from "next/image";
 import Icon from "components/atoms/Icon/icon";
 import Tooltip from "components/atoms/Tooltip/tooltip";
-import { StaticImageData } from "next/image";
 
 export interface RepoList {
   repoOwner: string;

--- a/components/molecules/CollaborationCard/collaboration-card.tsx
+++ b/components/molecules/CollaborationCard/collaboration-card.tsx
@@ -1,6 +1,6 @@
 import React from "react";
-import Avatar from "components/atoms/Avatar/avatar";
 import clsx from "clsx";
+import Avatar from "components/atoms/Avatar/avatar";
 import { getAvatarByUsername } from "lib/utils/github";
 import Button from "components/atoms/Button/button";
 

--- a/components/molecules/CollaborationSummaryCard/collaboration-summary-card.tsx
+++ b/components/molecules/CollaborationSummaryCard/collaboration-summary-card.tsx
@@ -1,9 +1,9 @@
 import { TbMessageCode } from "react-icons/tb";
 
-import Avatar from "components/atoms/Avatar/avatar";
 import React from "react";
-import { CollaborationRequestObject } from "../CollaborationCard/collaboration-card";
 import { BiMessage } from "react-icons/bi";
+import Avatar from "components/atoms/Avatar/avatar";
+import { CollaborationRequestObject } from "../CollaborationCard/collaboration-card";
 
 interface CollaborationSummaryCardProps {
   requests: CollaborationRequestObject[];

--- a/components/molecules/ContributorHighlight/contributor-highlight-card.tsx
+++ b/components/molecules/ContributorHighlight/contributor-highlight-card.tsx
@@ -1,5 +1,14 @@
-import Title from "components/atoms/Typography/title";
 import React, { useState, useEffect } from "react";
+import { HiOutlineEmojiHappy } from "react-icons/hi";
+import { TfiMoreAlt } from "react-icons/tfi";
+import { FiEdit, FiLinkedin, FiTwitter } from "react-icons/fi";
+import { BsCalendar2Event, BsLink45Deg } from "react-icons/bs";
+import { FaUserPlus } from "react-icons/fa";
+import { GrFlag } from "react-icons/gr";
+import Emoji from "react-emoji-render";
+import { MdError } from "react-icons/md";
+import { format } from "date-fns";
+import Title from "components/atoms/Typography/title";
 
 import { Textarea } from "components/atoms/Textarea/text-area";
 import Button from "components/atoms/Button/button";
@@ -9,15 +18,17 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "components/atoms/Dropdown/dropdown";
-import { HiOutlineEmojiHappy } from "react-icons/hi";
-import { TfiMoreAlt } from "react-icons/tfi";
-import { FiEdit, FiLinkedin, FiTwitter } from "react-icons/fi";
-import { BsCalendar2Event, BsLink45Deg } from "react-icons/bs";
-import { FaUserPlus } from "react-icons/fa";
-import { GrFlag } from "react-icons/gr";
-import Emoji from "react-emoji-render";
 
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
+import { generateApiPrUrl } from "lib/utils/github";
+import { fetchGithubPRInfo } from "lib/hooks/fetchGithubPRInfo";
+import { updateHighlights } from "lib/hooks/updateHighlight";
+import { deleteHighlight } from "lib/hooks/deleteHighlight";
+import { useToast } from "lib/hooks/useToast";
+import useFollowUser from "lib/hooks/useFollowUser";
+import useHighlightReactions from "lib/hooks/useHighlightReactions";
+import useUserHighlightReactions from "lib/hooks/useUserHighlightReactions";
+import Tooltip from "components/atoms/Tooltip/tooltip";
 import GhOpenGraphImg from "../GhOpenGraphImg/gh-open-graph-img";
 import {
   Dialog,
@@ -27,10 +38,6 @@ import {
   DialogDescription,
   DialogCloseButton,
 } from "../Dialog/dialog";
-import { generateApiPrUrl } from "lib/utils/github";
-import { fetchGithubPRInfo } from "lib/hooks/fetchGithubPRInfo";
-import { updateHighlights } from "lib/hooks/updateHighlight";
-import { MdError } from "react-icons/md";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -41,17 +48,8 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "../AlertDialog/alert-dialog";
-import { deleteHighlight } from "lib/hooks/deleteHighlight";
-import { useToast } from "lib/hooks/useToast";
-import useFollowUser from "lib/hooks/useFollowUser";
-import useFetchAllEmojis from "lib/hooks/useFetchAllEmojis";
-import useHighlightReactions from "lib/hooks/useHighlightReactions";
-import useUserHighlightReactions from "lib/hooks/useUserHighlightReactions";
-import { truncateString } from "lib/utils/truncate-string";
-import Tooltip from "components/atoms/Tooltip/tooltip";
 import { Popover, PopoverContent, PopoverTrigger } from "../Popover/popover";
 import { Calendar } from "../Calendar/calendar";
-import { format } from "date-fns";
 
 interface ContributorHighlightCardProps {
   title?: string;

--- a/components/molecules/ContributorHoverCard/contributor-hover-card.tsx
+++ b/components/molecules/ContributorHoverCard/contributor-hover-card.tsx
@@ -1,8 +1,8 @@
 import { useRouter } from "next/router";
 
+import { calcDistanceFromToday } from "lib/utils/date-utils";
 import CardProfile from "../CardProfile/card-profile";
 import CardRepoList, { RepoList } from "../CardRepoList/card-repo-list";
-import { calcDistanceFromToday } from "lib/utils/date-utils";
 import PullRequestTable from "../PullRequestTable/pull-request-table";
 
 export interface ContributorsProfileType {

--- a/components/molecules/ContributorListTableHeader/contributor-list-table-header.tsx
+++ b/components/molecules/ContributorListTableHeader/contributor-list-table-header.tsx
@@ -1,7 +1,7 @@
 import clsx from "clsx";
+import React from "react";
 import TableTitle from "components/atoms/TableTitle/table-title";
 import { classNames } from "components/organisms/RepositoriesTable/repositories-table";
-import React from "react";
 
 const ContributorListTableHeaders = () => {
   return (

--- a/components/molecules/ContributorListTableRow/contributor-list-table-row.tsx
+++ b/components/molecules/ContributorListTableRow/contributor-list-table-row.tsx
@@ -2,16 +2,16 @@ import React, { useEffect, useState } from "react";
 import clsx from "clsx";
 import formatDistanceToNowStrict from "date-fns/formatDistanceToNowStrict";
 
-import DevProfile from "../DevProfile/dev-profile";
 import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/solid";
 import Sparkline from "components/atoms/Sparkline/sparkline";
 import getPullRequestsToDays from "lib/utils/get-prs-to-days";
 import { classNames } from "components/organisms/RepositoriesTable/repositories-table";
 
 import useContributorPullRequests from "lib/hooks/api/useContributorPullRequests";
-import { getActivity } from "../RepoRow/repo-row";
 import useRepoList from "lib/hooks/useRepoList";
 import { useFetchUser } from "lib/hooks/useFetchUser";
+import { getActivity } from "../RepoRow/repo-row";
+import DevProfile from "../DevProfile/dev-profile";
 
 interface ContributorListTableRow {
   contributor: DbPRContributor;

--- a/components/molecules/ContributorProfileHeader/contributor-profile-header.tsx
+++ b/components/molecules/ContributorProfileHeader/contributor-profile-header.tsx
@@ -9,7 +9,6 @@ import { usePostHog } from "posthog-js/react";
 import Avatar from "components/atoms/Avatar/avatar";
 import RainbowBg from "img/rainbow-cover.png";
 import Button from "components/atoms/Button/button";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../Dialog/dialog";
 import { Textarea } from "components/atoms/Textarea/text-area";
 import {
   DropdownMenu,
@@ -20,6 +19,7 @@ import {
 
 import { useUserCollaborations } from "lib/hooks/useUserCollaborations";
 import { useToast } from "lib/hooks/useToast";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../Dialog/dialog";
 
 interface ContributorProfileHeaderProps {
   avatarUrl?: string;

--- a/components/molecules/ContributorProfileInfo/contributor-profile-info.tsx
+++ b/components/molecules/ContributorProfileInfo/contributor-profile-info.tsx
@@ -4,11 +4,11 @@ import Link from "next/link";
 import { AiOutlineGift } from "react-icons/ai";
 import { FiClock, FiGithub, FiLinkedin, FiTwitter } from "react-icons/fi";
 
+import clsx from "clsx";
 import LanguagePill from "components/atoms/LanguagePill/LanguagePill";
 import Title from "components/atoms/Typography/title";
 import Badge from "components/atoms/Badge/badge";
 import { getTimeByTimezone, getTimezone } from "lib/utils/timezones";
-import clsx from "clsx";
 import Tooltip from "components/atoms/Tooltip/tooltip";
 import { getFormattedDate } from "lib/utils/date-utils";
 

--- a/components/molecules/DevCard/dev-card.tsx
+++ b/components/molecules/DevCard/dev-card.tsx
@@ -4,17 +4,17 @@ import Image from "next/image";
 import cntl from "cntl";
 import { useEffect, useRef, useState } from "react";
 import { useMouse } from "react-use";
-import Button from "components/atoms/Button/button";
 import { ArrowTrendingUpIcon, MinusSmallIcon, ArrowSmallUpIcon, ArrowSmallDownIcon } from "@heroicons/react/24/solid";
 import { GiftIcon } from "@heroicons/react/24/outline";
+import Link from "next/link";
+import clsx from "clsx";
+import Button from "components/atoms/Button/button";
 import Pill, { PillProps } from "components/atoms/Pill/pill";
 import Icon from "components/atoms/Icon/icon";
 import CardSauceBGSVG from "img/card-sauce-bg.svg";
 import openSaucedImg from "img/openSauced-icon.png";
 import PRIcon from "img/icons/pr-icon.svg";
-import Link from "next/link";
 import { getRelativeDays } from "lib/utils/date-utils";
-import clsx from "clsx";
 
 type Activity = "high" | "mid";
 

--- a/components/molecules/FavoriteRepoCard/favorite-repo-card.tsx
+++ b/components/molecules/FavoriteRepoCard/favorite-repo-card.tsx
@@ -1,7 +1,7 @@
+import Link from "next/link";
 import Avatar from "components/atoms/Avatar/avatar";
 import { truncateString } from "lib/utils/truncate-string";
 import type { StaticImageData } from "next/image";
-import Link from "next/link";
 
 export interface FavoriteRepoCardProps {
   avatarURL: string | StaticImageData;

--- a/components/molecules/FilterCardSelect/filter-card-select.tsx
+++ b/components/molecules/FilterCardSelect/filter-card-select.tsx
@@ -1,13 +1,13 @@
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 import Image from "next/image";
 
 import { BsFillCheckCircleFill } from "react-icons/bs";
 
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "components/atoms/Select/select";
 import hashIcon from "../../../img/icons/hash.svg";
 import orgIcon from "../../../img/icons/org.svg";
 import personIcon from "../../../img/icons/person.svg";
 import repoIcon from "../../../img/icons/repo.svg";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "components/atoms/Select/select";
 
 interface FilterCardSelectProps {
   selected: string;

--- a/components/molecules/HeaderLogo/header-logo.tsx
+++ b/components/molecules/HeaderLogo/header-logo.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import Image from "next/image";
+import Link from "next/link";
 import openSaucedImg from "../../../img/openSauced-icon.png";
 import openSaucedImgWithBg from "../../../img/open-sourced-with-bg-icon.png";
-import Link from "next/link";
 
 interface HeaderLogoProps {
   textIsBlack?: boolean;

--- a/components/molecules/HighlightCard/highlight-card.tsx
+++ b/components/molecules/HighlightCard/highlight-card.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import Image from "next/image";
+import Card from "components/atoms/Card/card";
+import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
 import repoIcon from "../../../img/icons/icon-repo--blue.svg";
 import prIcon from "../../../img/icons/icon-pr--green.svg";
 import personIcon from "../../../img/icons/person-icon.svg";
 import labelIcon from "../../../img/icons/icon-label--blue.svg";
 import thumbsIcon from "../../../img/icons/icon-thumbs-down--yellow.svg";
 import metricArrow from "../../../img/icons/metric-arrow.svg";
-import Card from "components/atoms/Card/card";
 import StackedAvatar, { Contributor } from "../StackedAvatar/stacked-avatar";
-import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
 
 interface HighlightCardProps {
   className?: string;

--- a/components/molecules/HighlightInput/highlight-input-form.tsx
+++ b/components/molecules/HighlightInput/highlight-input-form.tsx
@@ -5,16 +5,16 @@ import { format } from "date-fns";
 
 import Button from "components/atoms/Button/button";
 import { Textarea } from "components/atoms/Textarea/text-area";
-import GhOpenGraphImg from "../GhOpenGraphImg/gh-open-graph-img";
-import { Popover, PopoverContent, PopoverTrigger } from "../Popover/popover";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../Collapsible/collapsible";
 import Tooltip from "components/atoms/Tooltip/tooltip";
-import { Calendar } from "../Calendar/calendar";
 
 import { createHighlights } from "lib/hooks/createHighlights";
 import { generateApiPrUrl } from "lib/utils/github";
 import { fetchGithubPRInfo } from "lib/hooks/fetchGithubPRInfo";
 import { useToast } from "lib/hooks/useToast";
+import { Calendar } from "../Calendar/calendar";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../Collapsible/collapsible";
+import { Popover, PopoverContent, PopoverTrigger } from "../Popover/popover";
+import GhOpenGraphImg from "../GhOpenGraphImg/gh-open-graph-img";
 
 interface HighlightInputFormProps {
   refreshCallback?: Function;

--- a/components/molecules/HighlightPrompt/highlight-prompt.tsx
+++ b/components/molecules/HighlightPrompt/highlight-prompt.tsx
@@ -1,5 +1,5 @@
-import Button from "components/atoms/Button/button";
 import React from "react";
+import Button from "components/atoms/Button/button";
 
 interface HighlightPromptProps extends React.HTMLAttributes<HTMLDivElement> {
   prompt: string;

--- a/components/molecules/HighlightsFeedCard/highlights-filter-card.tsx
+++ b/components/molecules/HighlightsFeedCard/highlights-filter-card.tsx
@@ -1,6 +1,6 @@
+import { useEffect, useState } from "react";
 import Title from "components/atoms/Typography/title";
 import Icon from "components/atoms/Icon/icon";
-import { useEffect, useState } from "react";
 
 interface HighlightsFilterCardProps {
   repos: { repoName: string; repoIcon: string; full_name: string }[];

--- a/components/molecules/HoverCardWrapper/hover-card-wrapper.tsx
+++ b/components/molecules/HoverCardWrapper/hover-card-wrapper.tsx
@@ -1,10 +1,10 @@
 import { useRouter } from "next/router";
 
-import ContributorHoverCard, { ContributorsProfileType } from "../ContributorHoverCard/contributor-hover-card";
 
 import { useFetchUser } from "lib/hooks/useFetchUser";
 import { useContributorPullRequestsChart } from "lib/hooks/useContributorPullRequestsChart";
 import { getAvatarByUsername } from "lib/utils/github";
+import ContributorHoverCard, { ContributorsProfileType } from "../ContributorHoverCard/contributor-hover-card";
 
 interface HoverCardWrapperProps {
   username: string;

--- a/components/molecules/InsightHeader/insight-header.tsx
+++ b/components/molecules/InsightHeader/insight-header.tsx
@@ -9,10 +9,10 @@ import Button from "components/atoms/Button/button";
 import Title from "components/atoms/Typography/title";
 import Badge from "components/atoms/InsightBadge/insight-badge";
 import ContextThumbnail from "components/atoms/ContextThumbnail/context-thumbnail";
-import CardRepoList from "../CardRepoList/card-repo-list";
 import { truncateString } from "lib/utils/truncate-string";
 import useRepositories from "lib/hooks/api/useRepositories";
 import { useToast } from "lib/hooks/useToast";
+import CardRepoList from "../CardRepoList/card-repo-list";
 
 interface InsightHeaderProps {
   insight?: DbUserInsight;

--- a/components/molecules/InsightPageCard/insight-page-card.tsx
+++ b/components/molecules/InsightPageCard/insight-page-card.tsx
@@ -9,10 +9,10 @@ import Text from "components/atoms/Typography/text";
 import { getRelativeDays } from "lib/utils/date-utils";
 import getRepoInsights from "lib/utils/get-repo-insights";
 
+import useRepositories from "lib/hooks/api/useRepositories";
 import CardRepoList from "../CardRepoList/card-repo-list";
 import PieChart, { PieData } from "../PieChart/pie-chart";
 import StackedAvatar from "../StackedAvatar/stacked-avatar";
-import useRepositories from "lib/hooks/api/useRepositories";
 
 interface InsightPageCardProps {
   user: User | null;

--- a/components/molecules/InsightRow/insight-row.tsx
+++ b/components/molecules/InsightRow/insight-row.tsx
@@ -7,11 +7,11 @@ import { User } from "@supabase/supabase-js";
 import { getRelativeDays } from "lib/utils/date-utils";
 import useRepositories from "lib/hooks/api/useRepositories";
 import getRepoInsights from "lib/utils/get-repo-insights";
+import Text from "components/atoms/Typography/text";
+import Pill from "components/atoms/Pill/pill";
 import getPercent from "../../../lib/utils/get-percent";
 
 import CardRepoList from "../CardRepoList/card-repo-list";
-import Text from "components/atoms/Typography/text";
-import Pill from "components/atoms/Pill/pill";
 
 interface InsightRowProps {
   insight: DbUserInsight;

--- a/components/molecules/InsightTableRow/insight-table-row.tsx
+++ b/components/molecules/InsightTableRow/insight-table-row.tsx
@@ -4,9 +4,6 @@ import { User } from "@supabase/supabase-js";
 import clsx from "clsx";
 
 import Pill from "components/atoms/Pill/pill";
-import CardRepoList from "../CardRepoList/card-repo-list";
-import PullRequestOverview from "../PullRequestOverview/pull-request-overview";
-import StackedAvatar from "../StackedAvatar/stacked-avatar";
 import FavoriteSelector from "components/atoms/FavoriteSelector/favorite-selector";
 import { classNames } from "components/organisms/RepositoriesTable/repositories-table";
 import Button from "components/atoms/Button/button";
@@ -14,6 +11,9 @@ import Button from "components/atoms/Button/button";
 import useRepositories from "lib/hooks/api/useRepositories";
 import { getRelativeDays } from "lib/utils/date-utils";
 import getRepoInsights from "lib/utils/get-repo-insights";
+import StackedAvatar from "../StackedAvatar/stacked-avatar";
+import PullRequestOverview from "../PullRequestOverview/pull-request-overview";
+import CardRepoList from "../CardRepoList/card-repo-list";
 
 interface InsightRepoRowProps {
   user: User | null;

--- a/components/molecules/InsightsPageListDropdown/insights-page-list-dropdown.tsx
+++ b/components/molecules/InsightsPageListDropdown/insights-page-list-dropdown.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import { BsPlusCircleFill } from "react-icons/bs";
 import Button from "components/atoms/Button/button";
 import {
   DropdownMenu,
@@ -8,7 +9,6 @@ import {
   DropdownMenuTrigger
 } from "components/atoms/Dropdown/dropdown";
 import InsightsPageListItem from "components/atoms/InsightsPageListItem/insights-page-list-item";
-import { BsPlusCircleFill } from "react-icons/bs";
 
 const InsightsPageListDropdown = () => {
   return (

--- a/components/molecules/NivoScatterChart/nivo-scatter-chart.tsx
+++ b/components/molecules/NivoScatterChart/nivo-scatter-chart.tsx
@@ -1,5 +1,4 @@
-import { useRouter } from "next/router";
-import { MouseEvent, useCallback, useState } from "react";
+import { useState } from "react";
 
 import { ResponsiveScatterPlot, ScatterPlotNodeProps } from "@nivo/scatterplot";
 import { animated } from "@react-spring/web";

--- a/components/molecules/OnboardingButton/onboarding-button.tsx
+++ b/components/molecules/OnboardingButton/onboarding-button.tsx
@@ -1,7 +1,7 @@
 import React from "react";
+import Link from "next/link";
 import Text from "components/atoms/Typography/text";
 import ProgressPie from "components/atoms/ProgressPie/progress-pie";
-import Link from "next/link";
 
 const OnboardingButton: React.FC = () => {
   return (

--- a/components/molecules/PageHeader/page-header.tsx
+++ b/components/molecules/PageHeader/page-header.tsx
@@ -1,5 +1,5 @@
-import Title from "components/atoms/Typography/title";
 import React from "react";
+import Title from "components/atoms/Typography/title";
 interface PageHeaderProps {
   title: string;
   rightComponent: React.ReactNode;

--- a/components/molecules/PullRequestSocialCard/pull-request-social-card.tsx
+++ b/components/molecules/PullRequestSocialCard/pull-request-social-card.tsx
@@ -2,9 +2,9 @@ import { IconContext } from "react-icons";
 import { VscGitPullRequest } from "react-icons/vsc";
 import { FaRegCommentAlt } from "react-icons/fa";
 
-import CardHorizontalBarChart, { LanguageObject } from "../CardHorizontalBarChart/card-horizontal-bar-chart";
 import Text from "components/atoms/Typography/text";
 import Avatar from "components/atoms/Avatar/avatar";
+import CardHorizontalBarChart, { LanguageObject } from "../CardHorizontalBarChart/card-horizontal-bar-chart";
 
 interface PullRequestSocialCardProps {
   orgName: string;

--- a/components/molecules/RecommendedRepoCard/recommended-repo-card.tsx
+++ b/components/molecules/RecommendedRepoCard/recommended-repo-card.tsx
@@ -1,15 +1,15 @@
-import humanizeNumber from "lib/utils/humanizeNumber";
 import { BiGitPullRequest } from "react-icons/bi";
 import { VscIssues } from "react-icons/vsc";
 import { AiOutlineStar } from "react-icons/ai";
-import { getAvatarByUsername } from "lib/utils/github";
-import StackedAvatar, { Contributor } from "../StackedAvatar/stacked-avatar";
 import clsx from "clsx";
+import { getAvatarByUsername } from "lib/utils/github";
+import humanizeNumber from "lib/utils/humanizeNumber";
 import useFetchRecommendedRepoByRepoName from "lib/hooks/fetchRecommendationByRepo";
 import { truncateString } from "lib/utils/truncate-string";
 import useRepositoryPullRequests from "lib/hooks/api/useRepositoryPullRequests";
 import getPullRequestsContributors from "lib/utils/get-pr-contributors";
 import { Spinner } from "components/atoms/SpinLoader/spin-loader";
+import StackedAvatar from "../StackedAvatar/stacked-avatar";
 
 export declare interface RecommendedRepoCardProps extends React.ComponentProps<"div"> {
   fullName: string;

--- a/components/molecules/RepoCardProfile/repo-card-profile.tsx
+++ b/components/molecules/RepoCardProfile/repo-card-profile.tsx
@@ -1,7 +1,7 @@
-import Avatar from "components/atoms/Avatar/avatar";
 import { StaticImageData } from "next/image";
 import { BiGitPullRequest } from "react-icons/bi";
 import { VscIssues } from "react-icons/vsc";
+import Avatar from "components/atoms/Avatar/avatar";
 
 export interface RepoCardProfileProps {
   avatar?: string | StaticImageData;

--- a/components/molecules/RepoRow/repo-row.tsx
+++ b/components/molecules/RepoRow/repo-row.tsx
@@ -12,9 +12,6 @@ import { RepositoriesRows } from "components/organisms/RepositoriesTable/reposit
 import Pill from "components/atoms/Pill/pill";
 import Sparkline from "components/atoms/Sparkline/sparkline";
 import { classNames } from "components/organisms/RepositoriesTable/repositories-table";
-import StackedAvatar from "../StackedAvatar/stacked-avatar";
-import PullRequestOverview from "../PullRequestOverview/pull-request-overview";
-import TableRepositoryName from "../TableRepositoryName/table-repository-name";
 import Checkbox from "components/atoms/Checkbox/checkbox";
 
 import { getRelativeDays } from "lib/utils/date-utils";
@@ -25,6 +22,9 @@ import useRepositoryPullRequests from "lib/hooks/api/useRepositoryPullRequests";
 import getPullRequestsToDays from "lib/utils/get-prs-to-days";
 import getPullRequestsContributors from "lib/utils/get-pr-contributors";
 import useStore from "lib/store";
+import TableRepositoryName from "../TableRepositoryName/table-repository-name";
+import PullRequestOverview from "../PullRequestOverview/pull-request-overview";
+import StackedAvatar from "../StackedAvatar/stacked-avatar";
 
 interface RepoProps {
   repo: RepositoriesRows;

--- a/components/molecules/ReposoitoryCartItem/repository-cart-item.tsx
+++ b/components/molecules/ReposoitoryCartItem/repository-cart-item.tsx
@@ -1,8 +1,8 @@
-import Avatar from "components/atoms/Avatar/avatar";
-import Text from "components/atoms/Typography/text";
 import { StaticImageData } from "next/image";
 import { AiOutlineClose } from "react-icons/ai";
 import { BiGitPullRequest } from "react-icons/bi";
+import Text from "components/atoms/Typography/text";
+import Avatar from "components/atoms/Avatar/avatar";
 
 export interface RepositoryCartItemProps {
   avatar?: StaticImageData | string;

--- a/components/molecules/SelectReportsFilter/select-reports-filter.tsx
+++ b/components/molecules/SelectReportsFilter/select-reports-filter.tsx
@@ -1,9 +1,9 @@
+import { useState } from "react";
 import Button from "components/atoms/Button/button";
 import Text from "components/atoms/Typography/text";
 import Title from "components/atoms/Typography/title";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "components/atoms/Select/select";
 import { FilterOptions } from "interfaces/filter-object-types";
-import { useState } from "react";
 
 interface SelectReportsFilterProps {
   filterList: FilterOptions[];

--- a/components/molecules/SuperlativeSelector/superlative-selector.tsx
+++ b/components/molecules/SuperlativeSelector/superlative-selector.tsx
@@ -1,11 +1,11 @@
-import ContextFilterButton from "components/atoms/ContextFilterButton/context-filter-button";
 
 import React, { useEffect, useRef, useState } from "react";
-import Icon from "../../atoms/Icon/icon";
+import ContextFilterButton from "components/atoms/ContextFilterButton/context-filter-button";
 import cancelIcon from "img/x-circle.svg";
 import Radio from "components/atoms/Radio/radio";
 import humanizeNumber from "lib/utils/humanizeNumber";
 import getFilterKey from "lib/utils/get-filter-key";
+import Icon from "../../atoms/Icon/icon";
 
 interface SuperlativeSelectorProps {
   filterOptions: string[];

--- a/components/molecules/TableHeader/table-header.tsx
+++ b/components/molecules/TableHeader/table-header.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import { useRouter } from "next/router";
-import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
 import { useDebounce } from "rooks";
+import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
 
 import Search from "components/atoms/Search/search";
 import Title from "components/atoms/Typography/title";
-import ComponentDateFilter from "../ComponentDateFilter/component-date-filter";
-import PaginationResult from "../PaginationResults/pagination-result";
 import LimitSelect from "components/atoms/Select/limit-select";
 import LayoutToggle, { ToggleValue } from "components/atoms/LayoutToggle/layout-toggle";
+import ComponentDateFilter from "../ComponentDateFilter/component-date-filter";
+import PaginationResult from "../PaginationResults/pagination-result";
 
 interface TableHeaderProps {
   title?: string;

--- a/components/molecules/TableRepositoryName/table-repository-name.tsx
+++ b/components/molecules/TableRepositoryName/table-repository-name.tsx
@@ -1,6 +1,6 @@
+import { StaticImageData } from "next/image";
 import Avatar from "components/atoms/Avatar/avatar";
 import { truncateString } from "lib/utils/truncate-string";
-import { StaticImageData } from "next/image";
 
 interface TableRepositoryNameProps {
   avatarURL?: string | StaticImageData;

--- a/components/molecules/TeamMemberRow/team-member-row.tsx
+++ b/components/molecules/TeamMemberRow/team-member-row.tsx
@@ -6,8 +6,8 @@ import { BsCheck2 } from "react-icons/bs";
 import pendingImg from "img/icons/fallback-image-disabled-square.svg";
 
 import Avatar from "components/atoms/Avatar/avatar";
-import { MemberAccess, TeamMemberData } from "../TeamMembersConfig/team-members-config";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "components/atoms/Select/select";
+import { MemberAccess, TeamMemberData } from "../TeamMembersConfig/team-members-config";
 
 interface TeamMemberRowProps extends TeamMemberData {
   className?: string;

--- a/components/molecules/TeamMembersConfig/team-members-config.tsx
+++ b/components/molecules/TeamMembersConfig/team-members-config.tsx
@@ -1,9 +1,9 @@
+import { useState } from "react";
 import Button from "components/atoms/Button/button";
 import Search from "components/atoms/Search/search";
-import TeamMemberRow from "../TeamMemberRow/team-member-row";
-import { useState } from "react";
 import { validateEmail } from "lib/utils/validate-email";
 import { useToast } from "lib/hooks/useToast";
+import TeamMemberRow from "../TeamMemberRow/team-member-row";
 
 interface TeamMembersConfigProps {
   className?: string;

--- a/components/molecules/TopUsersPanel/top-user-panel.tsx
+++ b/components/molecules/TopUsersPanel/top-user-panel.tsx
@@ -1,5 +1,5 @@
-import TopUserCard, { TopUserCardProps } from "components/atoms/TopUserCard/top-user-card";
 import React from "react";
+import TopUserCard, { TopUserCardProps } from "components/atoms/TopUserCard/top-user-card";
 
 interface TopUsersPanelProps {
   users: TopUserCardProps[];

--- a/components/organisms/CollaborationRequestWrapper/collaboration-requests-wrapper.tsx
+++ b/components/organisms/CollaborationRequestWrapper/collaboration-requests-wrapper.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { format, isToday, isYesterday, formatDistanceToNowStrict } from "date-fns";
+import React from "react";
+import { isToday, isYesterday, formatDistanceToNowStrict } from "date-fns";
 import CollaborationCard from "components/molecules/CollaborationCard/collaboration-card";
 import { useUserCollaborations } from "lib/hooks/useUserCollaborations";
 import DashContainer from "components/atoms/DashedContainer/DashContainer";

--- a/components/organisms/ContributorProfilePage/contributor-profile-page.tsx
+++ b/components/organisms/ContributorProfilePage/contributor-profile-page.tsx
@@ -1,7 +1,6 @@
 import Title from "components/atoms/Typography/title";
 import Text from "components/atoms/Typography/text";
 import ContributorProfileHeader from "components/molecules/ContributorProfileHeader/contributor-profile-header";
-import { ContributorObject } from "../ContributorCard/contributor-card";
 import CardLineChart from "components/molecules/CardLineChart/card-line-chart";
 import CardRepoList from "components/molecules/CardRepoList/card-repo-list";
 import PullRequestTable from "components/molecules/PullRequestTable/pull-request-table";
@@ -13,10 +12,11 @@ import { getRelativeDays } from "lib/utils/date-utils";
 import Pill from "components/atoms/Pill/pill";
 import getPercent from "lib/utils/get-percent";
 import ContributorProfileInfo from "components/molecules/ContributorProfileInfo/contributor-profile-info";
-import ContributorProfileTab from "../ContributorProfileTab/contributor-profile-tab";
 import ProfileLanguageChart from "components/molecules/ProfileLanguageChart/profile-language-chart";
 import useFollowUser from "lib/hooks/useFollowUser";
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
+import ContributorProfileTab from "../ContributorProfileTab/contributor-profile-tab";
+import { ContributorObject } from "../ContributorCard/contributor-card";
 
 const colorKeys = Object.keys(color);
 interface PrObjectType {

--- a/components/organisms/Contributors/contributors.tsx
+++ b/components/organisms/Contributors/contributors.tsx
@@ -8,7 +8,6 @@ import TableHeader from "components/molecules/TableHeader/table-header";
 
 import { calcDistanceFromToday } from "lib/utils/date-utils";
 
-import ContributorCard from "../ContributorCard/contributor-card";
 import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
 import LimitSelect from "components/atoms/Select/limit-select";
 
@@ -16,6 +15,7 @@ import useContributors from "lib/hooks/api/useContributors";
 import { getAvatarByUsername } from "lib/utils/github";
 import { ToggleValue } from "components/atoms/LayoutToggle/layout-toggle";
 import ContributorListTableHeaders from "components/molecules/ContributorListTableHeader/contributor-list-table-header";
+import ContributorCard from "../ContributorCard/contributor-card";
 import ContributorTable from "../ContributorsTable/contributors-table";
 
 interface ContributorProps {

--- a/components/organisms/ContributorsTable/contributors-table.tsx
+++ b/components/organisms/ContributorsTable/contributors-table.tsx
@@ -1,6 +1,6 @@
+import React from "react";
 import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
 import ContributorListTableRow from "components/molecules/ContributorListTableRow/contributor-list-table-row";
-import React from "react";
 
 export interface ContributorTableProps {
   contributors: DbPRContributor[];

--- a/components/organisms/DevCardCarousel/dev-card-carousel.test.tsx
+++ b/components/organisms/DevCardCarousel/dev-card-carousel.test.tsx
@@ -5,8 +5,8 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import DevCardCarousel from "./dev-card-carousel";
 import { STUB_DEV_CARDS } from "components/organisms/DevCardCarousel/stubData";
+import DevCardCarousel from "./dev-card-carousel";
 
 describe("DevCardCarousel", () => {
   it("should render", () => {

--- a/components/organisms/DevCardCarousel/dev-card-carousel.tsx
+++ b/components/organisms/DevCardCarousel/dev-card-carousel.tsx
@@ -1,9 +1,9 @@
 import cntl from "cntl";
-import DevCard, { DevCardProps } from "components/molecules/DevCard/dev-card";
 import { animated, to, useSprings } from "react-spring";
 import { useGesture } from "@use-gesture/react";
 import { useCallback, useEffect, useState } from "react";
 import { useKey } from "react-use";
+import DevCard, { DevCardProps } from "components/molecules/DevCard/dev-card";
 
 export interface DevCardCarouselProps {
   cards: DevCardProps[];

--- a/components/organisms/Footer/footer.tsx
+++ b/components/organisms/Footer/footer.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import Image from "next/image";
-import OpenSaucedLogo from "img/openSauced-icon.png";
-import Text from "components/atoms/Typography/text";
 
 // icons
 import { AiOutlineTwitter } from "react-icons/ai";
@@ -10,6 +8,8 @@ import { AiFillInstagram } from "react-icons/ai";
 import { AiFillYoutube } from "react-icons/ai";
 import { FaDiscord } from "react-icons/fa";
 import { FaDev } from "react-icons/fa";
+import Text from "components/atoms/Typography/text";
+import OpenSaucedLogo from "img/openSauced-icon.png";
 
 const footerContext = [
   {

--- a/components/organisms/InsightPage/DeleteInsightPageModal.tsx
+++ b/components/organisms/InsightPage/DeleteInsightPageModal.tsx
@@ -1,10 +1,10 @@
 import { FC, useState } from "react";
+import clsx from "clsx";
 import Button from "components/atoms/Button/button";
 import TextInput from "components/atoms/TextInput/text-input";
 import Text from "components/atoms/Typography/text";
 import Title from "components/atoms/Typography/title";
 import { Dialog, DialogContent, DialogTitle } from "components/molecules/Dialog/dialog";
-import clsx from "clsx";
 
 interface ModalProps {
   open: boolean;

--- a/components/organisms/InsightPage/InsightPage.tsx
+++ b/components/organisms/InsightPage/InsightPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { UserGroupIcon } from "@heroicons/react/24/outline";
 
+import { useDebounce } from "rooks";
 import Button from "components/atoms/Button/button";
 import TextInput from "components/atoms/TextInput/text-input";
 import ToggleSwitch from "components/atoms/ToggleSwitch/toggle-switch";
@@ -10,7 +11,6 @@ import Title from "components/atoms/Typography/title";
 import RepositoriesCart from "components/organisms/RepositoriesCart/repositories-cart";
 import RepositoryCartItem from "components/molecules/ReposoitoryCartItem/repository-cart-item";
 import RepoNotIndexed from "components/organisms/Repositories/repository-not-indexed";
-import DeleteInsightPageModal from "./DeleteInsightPageModal";
 import useRepositories from "lib/hooks/api/useRepositories";
 
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
@@ -18,12 +18,12 @@ import { getAvatarById, getAvatarByUsername } from "lib/utils/github";
 import useStore from "lib/store";
 import Error from "components/atoms/Error/Error";
 import Search from "components/atoms/Search/search";
-import { useDebounce } from "rooks";
-import SuggestedRepositoriesList from "../SuggestedRepoList/suggested-repo-list";
 import { RepoCardProfileProps } from "components/molecules/RepoCardProfile/repo-card-profile";
 import { useToast } from "lib/hooks/useToast";
 import TeamMembersConfig, { TeamMemberData } from "components/molecules/TeamMembersConfig/team-members-config";
 import useInsightMembers from "lib/hooks/useInsightMembers";
+import SuggestedRepositoriesList from "../SuggestedRepoList/suggested-repo-list";
+import DeleteInsightPageModal from "./DeleteInsightPageModal";
 
 enum RepoLookupError {
   Initial = 0,

--- a/components/organisms/Reports/reports.tsx
+++ b/components/organisms/Reports/reports.tsx
@@ -8,13 +8,13 @@ import Icon from "components/atoms/Icon/icon";
 import Title from "components/atoms/Typography/title";
 import ReportsHistory from "components/molecules/ReportsHistory/reports-history";
 import SelectReportsFilter from "components/molecules/SelectReportsFilter/select-reports-filter";
-import StripeCheckoutButton from "../StripeCheckoutButton/stripe-checkout-button";
 
 import { Report } from "interfaces/report-type";
 
 import useFilterOptions from "lib/hooks/useFilterOptions";
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
 import getCurrentDate from "lib/utils/get-current-date";
+import StripeCheckoutButton from "../StripeCheckoutButton/stripe-checkout-button";
 
 const USERDEVICESTORAGENAME = "reportState";
 

--- a/components/organisms/Repositories/repositories.tsx
+++ b/components/organisms/Repositories/repositories.tsx
@@ -11,11 +11,11 @@ import useRepositories from "lib/hooks/api/useRepositories";
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
 import useStore from "lib/store";
 
-import RepositoriesTable, { classNames, RepositoriesRows } from "../RepositoriesTable/repositories-table";
-import RepoNotIndexed from "./repository-not-indexed";
 import Checkbox from "components/atoms/Checkbox/checkbox";
 import Button from "components/atoms/Button/button";
 import LimitSelect from "components/atoms/Select/limit-select";
+import RepositoriesTable, { classNames, RepositoriesRows } from "../RepositoriesTable/repositories-table";
+import RepoNotIndexed from "./repository-not-indexed";
 
 interface RepositoriesProps {
   repositories?: number[];

--- a/components/organisms/Repositories/repository-not-indexed.tsx
+++ b/components/organisms/Repositories/repository-not-indexed.tsx
@@ -1,5 +1,5 @@
-import Text from "components/atoms/Typography/text";
 import Link from "next/link";
+import Text from "components/atoms/Typography/text";
 
 const RepoNotIndexed = () => {
   return (

--- a/components/organisms/RepositoriesTable/repositories-table.tsx
+++ b/components/organisms/RepositoriesTable/repositories-table.tsx
@@ -1,10 +1,9 @@
-import type { StaticImageData } from "next/image";
 import { Serie } from "@nivo/line";
 
 import RepoRow from "components/molecules/RepoRow/repo-row";
 
-import { getAvatarByUsername } from "lib/utils/github";
 import SkeletonWrapper from "components/atoms/SkeletonLoader/skeleton-wrapper";
+import type { StaticImageData } from "next/image";
 
 interface ContributorsRows {
   name?: string;

--- a/components/organisms/SuggestedRepoList/suggested-repo-list.tsx
+++ b/components/organisms/SuggestedRepoList/suggested-repo-list.tsx
@@ -1,7 +1,7 @@
+import React from "react";
 import Title from "components/atoms/Typography/title";
 import { RepoCardProfileProps } from "components/molecules/RepoCardProfile/repo-card-profile";
 import SuggestedRepository from "components/molecules/SuggestedRepo/suggested-repo";
-import React from "react";
 
 interface SuggestedRepositoriesListProps {
   reposData: RepoCardProfileProps[];

--- a/components/organisms/ToolsDisplay/tools-display.tsx
+++ b/components/organisms/ToolsDisplay/tools-display.tsx
@@ -1,10 +1,10 @@
 import React from "react";
-import Contributors from "../Contributors/contributors";
 import { captureAnayltics } from "lib/utils/analytics";
+import useSession from "lib/hooks/useSession";
+import Contributors from "../Contributors/contributors";
 import Dashboard from "../Dashboard/dashboard";
 import Reports from "../Reports/reports";
 import Repositories from "../Repositories/repositories";
-import useSession from "lib/hooks/useSession";
 
 interface ToolProps {
   tool?: string;

--- a/components/organisms/Waitlist/waitlist.tsx
+++ b/components/organisms/Waitlist/waitlist.tsx
@@ -1,11 +1,11 @@
-import ComponentGradient from "../../molecules/ComponentGradient/component-gradient";
+import { FiArrowLeft } from "react-icons/fi";
+import { FaGithub } from "react-icons/fa";
 import HeaderLogo from "components/molecules/HeaderLogo/header-logo";
 import Text from "components/atoms/Typography/text";
 import Title from "components/atoms/Typography/title";
 import Button from "components/atoms/Button/button";
-import { FiArrowLeft } from "react-icons/fi";
-import { FaGithub } from "react-icons/fa";
 import AvatarRoll from "components/molecules/AvatarRoll/avatar-roll";
+import ComponentGradient from "../../molecules/ComponentGradient/component-gradient";
 const WaitlistComponent = () => {
   return (
     <ComponentGradient>

--- a/lib/hooks/api/useContributorPullRequests.ts
+++ b/lib/hooks/api/useContributorPullRequests.ts
@@ -1,4 +1,4 @@
-import useSWR, { Arguments, Fetcher } from "swr";
+import useSWR, { Fetcher } from "swr";
 import { useRouter } from "next/router";
 
 import publicApiFetcher from "lib/utils/public-api-fetcher";

--- a/lib/hooks/api/useInsights.ts
+++ b/lib/hooks/api/useInsights.ts
@@ -1,7 +1,7 @@
-import getFilterQuery from "lib/utils/get-filter-query";
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import { useRouter } from "next/router";
 import useSWR, { Fetcher } from "swr";
+import getFilterQuery from "lib/utils/get-filter-query";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 interface Insight {
   allReposTotal: number;

--- a/lib/hooks/fetchGithubPRInfo.ts
+++ b/lib/hooks/fetchGithubPRInfo.ts
@@ -1,5 +1,5 @@
-import { supabase } from "lib/utils/supabase";
 import { Octokit } from "octokit";
+import { supabase } from "lib/utils/supabase";
 
 interface GhPullInfoResponse {
   data: GhPRInfoResponse;

--- a/lib/hooks/fetchRecommendationByRepo.ts
+++ b/lib/hooks/fetchRecommendationByRepo.ts
@@ -1,5 +1,5 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 const useFetchRecommendedRepoByRepoName = (owner: string, repo: string) => {
   const { data, error, mutate } = useSWR<DbRepo, Error>(

--- a/lib/hooks/useContributorPullRequestsChart.ts
+++ b/lib/hooks/useContributorPullRequestsChart.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import getPullRequestsToDays from "lib/utils/get-prs-to-days";
-import useContributorPullRequests from "./api/useContributorPullRequests";
 import { RepoList } from "components/molecules/CardRepoList/card-repo-list";
 import { getAvatarByUsername } from "lib/utils/github";
+import useContributorPullRequests from "./api/useContributorPullRequests";
 
 const useContributorPullRequestsChart = (contributor: string, topic: string, repoIds: number[] = [], range = 30) => {
   const lineChart = {

--- a/lib/hooks/useFetchAllEmojis.ts
+++ b/lib/hooks/useFetchAllEmojis.ts
@@ -1,5 +1,5 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 interface PaginatedEmojiResponse {
   data: DbEmojis[];

--- a/lib/hooks/useFetchAllHighlights.ts
+++ b/lib/hooks/useFetchAllHighlights.ts
@@ -1,6 +1,6 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import { useState } from "react";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 interface useFetchUserHighlightsResponse {
   data: DbHighlight[];

--- a/lib/hooks/useFetchFollowingHighlightRepos.ts
+++ b/lib/hooks/useFetchFollowingHighlightRepos.ts
@@ -1,6 +1,6 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import { useState } from "react";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 interface useFetchUserHighlightsResponse {
   data: { full_name: string }[];

--- a/lib/hooks/useFetchFollowingHighlights.ts
+++ b/lib/hooks/useFetchFollowingHighlights.ts
@@ -1,6 +1,6 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import { useState } from "react";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 interface useFetchUserHighlightsResponse {
   data: DbHighlight[];

--- a/lib/hooks/useFetchHiglightRepos.ts
+++ b/lib/hooks/useFetchHiglightRepos.ts
@@ -1,6 +1,6 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import { useState } from "react";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 interface useFetchUserHighlightsResponse {
   data: { full_name: string }[];

--- a/lib/hooks/useFetchSingleHighlight.ts
+++ b/lib/hooks/useFetchSingleHighlight.ts
@@ -1,5 +1,5 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 interface useFetchUserHighlightsResponse {
   data: DbHighlight;

--- a/lib/hooks/useFetchUser.ts
+++ b/lib/hooks/useFetchUser.ts
@@ -1,5 +1,5 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import useSWR, { Fetcher, SWRConfiguration } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 interface UserResponse extends DbUser {}
 const useFetchUser = (username: string, config?: SWRConfiguration) => {

--- a/lib/hooks/useFetchUserHighlights.ts
+++ b/lib/hooks/useFetchUserHighlights.ts
@@ -1,6 +1,6 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import { useState } from "react";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 interface useFetchUserHighlightsResponse {
   data: DbHighlight[];

--- a/lib/hooks/useFilterPrefetch.ts
+++ b/lib/hooks/useFilterPrefetch.ts
@@ -2,8 +2,8 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useSWRConfig } from "swr";
 import getFilterKey from "lib/utils/get-filter-key";
-import useFilterOptions from "./useFilterOptions";
 import publicApiFetcher from "lib/utils/public-api-fetcher";
+import useFilterOptions from "./useFilterOptions";
 
 type FilterValues = { [name: string]: number | undefined };
 

--- a/lib/hooks/useFollowUser.ts
+++ b/lib/hooks/useFollowUser.ts
@@ -1,5 +1,5 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 import useSupabaseAuth from "./useSupabaseAuth";
 
 interface FollowUserResponse {

--- a/lib/hooks/useHighlightReactions.ts
+++ b/lib/hooks/useHighlightReactions.ts
@@ -1,5 +1,5 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 export interface HighlightReactionResponse {
   emoji_id: string;

--- a/lib/hooks/useInsight.ts
+++ b/lib/hooks/useInsight.ts
@@ -1,5 +1,5 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 const useInsight = (id: string) => {
   const baseEndpoint = `insights/${id}`;

--- a/lib/hooks/useInsightMembers.ts
+++ b/lib/hooks/useInsightMembers.ts
@@ -1,7 +1,7 @@
 import useSWR, { Fetcher } from "swr";
-import useSupabaseAuth from "./useSupabaseAuth";
 import publicApiFetcher from "lib/utils/public-api-fetcher";
 import { MemberAccess } from "components/molecules/TeamMembersConfig/team-members-config";
+import useSupabaseAuth from "./useSupabaseAuth";
 interface PaginatedInsightMembers {
   data: DbInsightMember[];
   meta: Meta;

--- a/lib/hooks/useUserCollaborations.ts
+++ b/lib/hooks/useUserCollaborations.ts
@@ -1,5 +1,5 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 import useSupabaseAuth from "./useSupabaseAuth";
 import { useToast } from "./useToast";
 

--- a/lib/hooks/useUserHighlightReactions.ts
+++ b/lib/hooks/useUserHighlightReactions.ts
@@ -1,6 +1,6 @@
 import useSWR, { Fetcher } from "swr";
-import { HighlightReactionResponse } from "./useHighlightReactions";
 import publicApiFetcher from "lib/utils/public-api-fetcher";
+import { HighlightReactionResponse } from "./useHighlightReactions";
 import useSupabaseAuth from "./useSupabaseAuth";
 
 const useUserHighlightReactions = (id: string) => {

--- a/lib/hooks/useUserInsights.ts
+++ b/lib/hooks/useUserInsights.ts
@@ -1,6 +1,6 @@
-import publicApiFetcher from "lib/utils/public-api-fetcher";
 import { useState } from "react";
 import useSWR, { Fetcher } from "swr";
+import publicApiFetcher from "lib/utils/public-api-fetcher";
 
 interface PaginatedInsightsResponse {
   readonly data: DbUserInsight[];

--- a/lib/store/index.ts
+++ b/lib/store/index.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 
-import { GlobalStateInterface } from "interfaces/global-state-types";
 import { User } from "@supabase/supabase-js";
+import { GlobalStateInterface } from "interfaces/global-state-types";
 
 const initialState: GlobalStateInterface = {
   range: 30,

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8,7 +8,7 @@
       "name": "@open-sauced/insights",
       "version": "1.55.0-beta.1",
       "hasInstallScript": true,
-      "license": "MIT",
+      "license": "Apache 2.0",
       "dependencies": {
         "@headlessui/react": "^1.7.8",
         "@heroicons/react": "^2.0.14",
@@ -99,6 +99,7 @@
         "eslint": "^8.33.0",
         "eslint-config-next": "^13.1.6",
         "eslint-config-prettier": "^8.8.0",
+        "eslint-plugin-unused-imports": "^2.0.0",
         "jest": "^28.1.3",
         "jest-environment-jsdom": "^29.5.0",
         "postcss": "^8.4.21",
@@ -22190,6 +22191,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "eslint": "^8.33.0",
     "eslint-config-next": "^13.1.6",
     "eslint-config-prettier": "^8.8.0",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^29.5.0",
     "postcss": "^8.4.21",

--- a/pages/[filterName]/[toolName].tsx
+++ b/pages/[filterName]/[toolName].tsx
@@ -1,9 +1,9 @@
-import FilterLayout from "../../layouts/filter";
-import { WithPageLayout } from "../../interfaces/with-page-layout";
 import { useRouter } from "next/router";
+import { useEffect } from "react";
 import Tool from "components/organisms/ToolsDisplay/tools-display";
 import changeCapitalization from "lib/utils/change-capitalization";
-import { useEffect } from "react";
+import FilterLayout from "../../layouts/filter";
+import { WithPageLayout } from "../../interfaces/with-page-layout";
 
 const Filter: WithPageLayout = () => {
   const router = useRouter();

--- a/pages/[filterName]/[toolName]/[filter]/[...selectedFilter].tsx
+++ b/pages/[filterName]/[toolName]/[filter]/[...selectedFilter].tsx
@@ -1,10 +1,10 @@
 import { useRouter } from "next/router";
 
+import { useEffect } from "react";
 import FilterLayout from "layouts/filter";
 import { WithPageLayout } from "interfaces/with-page-layout";
 import Tool from "components/organisms/ToolsDisplay/tools-display";
 import changeCapitalization from "lib/utils/change-capitalization";
-import { useEffect } from "react";
 
 const SelectedFilter: WithPageLayout = () => {
   const router = useRouter();

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,11 +5,13 @@ import "react-loading-skeleton/dist/skeleton.css";
 
 import { useEffect, useState } from "react";
 import Head from "next/head";
-import type { AppProps } from "next/app";
 import { useRouter } from "next/router";
 import { SessionContextProvider } from "@supabase/auth-helpers-react";
 import { SWRConfig } from "swr";
 
+import Script from "next/script";
+import posthog from "posthog-js";
+import { PostHogProvider } from "posthog-js/react";
 import { TipProvider } from "components/atoms/Tooltip/tooltip";
 
 import publicApiFetcher from "lib/utils/public-api-fetcher";
@@ -18,12 +20,10 @@ import { supabase } from "lib/utils/supabase";
 
 import SEO from "layouts/SEO/SEO";
 import { Toaster } from "components/molecules/Toaster/toaster";
-import Script from "next/script";
 import useSession from "lib/hooks/useSession";
 import PrivateWrapper from "layouts/private-wrapper";
 
-import posthog from "posthog-js";
-import { PostHogProvider } from "posthog-js/react";
+import type { AppProps } from "next/app";
 
 // Check that PostHog is client-side (used to handle Next.js SSR)
 if (typeof window !== "undefined") {

--- a/pages/feed/[id].tsx
+++ b/pages/feed/[id].tsx
@@ -1,7 +1,7 @@
 import { GetServerSidePropsContext } from "next";
 
-import Feed from "../feed";
 import fetchSocialCard from "lib/utils/fetch-social-card";
+import Feed from "../feed";
 
 export default Feed;
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,10 @@
-import { WithPageLayout } from "../interfaces/with-page-layout";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 
 import Loader from "components/templates/Loader/loader";
 import { supabase } from "lib/utils/supabase";
 import useSession from "lib/hooks/useSession";
+import { WithPageLayout } from "../interfaces/with-page-layout";
 
 const Home: WithPageLayout = () => {
   const router = useRouter();

--- a/pages/start.tsx
+++ b/pages/start.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import { User } from "@supabase/supabase-js";
 
+import { RiArrowDownSLine, RiArrowUpSLine } from "react-icons/ri";
 import CompletedIcon from "img/icons/completed-icon.svg";
 import GitHubAuthActiveIcon from "img/icons/github-auth-active-icon.svg";
 import ChooseTimezoneIcon from "img/icons/choose-timezone.svg";
@@ -31,7 +32,6 @@ import LanguagePill from "components/atoms/LanguagePill/LanguagePill";
 
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "components/atoms/Select/select";
 import { timezones } from "lib/utils/timezones";
-import { RiArrowDownSLine, RiArrowUpSLine } from "react-icons/ri";
 
 type handleLoginStep = () => void;
 

--- a/pages/user/[username]/card.tsx
+++ b/pages/user/[username]/card.tsx
@@ -1,11 +1,12 @@
+import { ParsedUrlQuery } from "querystring";
 import { GetServerSideProps, NextPage } from "next";
 import { useEffect, useState } from "react";
 import { useTransition, animated } from "react-spring";
+import Image from "next/image";
+import cntl from "cntl";
 import Button from "components/atoms/Button/button";
 import HeaderLogo from "components/molecules/HeaderLogo/header-logo";
 import DevCardCarousel, { DevCardCarouselProps } from "components/organisms/DevCardCarousel/dev-card-carousel";
-import BubbleBG from "../../../img/bubble-bg.svg";
-import { ParsedUrlQuery } from "querystring";
 import { getAvatarByUsername } from "lib/utils/github";
 import { fetchContributorPRs } from "lib/hooks/api/useContributorPullRequests";
 import getContributorPullRequestVelocity from "lib/utils/get-contributor-pr-velocity";
@@ -13,12 +14,11 @@ import getPercent from "lib/utils/get-percent";
 import { getRepoList } from "lib/hooks/useRepoList";
 import { DevCardProps } from "components/molecules/DevCard/dev-card";
 import SEO from "layouts/SEO/SEO";
-import TwitterIcon from "../../../img/icons/social-twitter.svg";
-import LinkinIcon from "../../../img/icons/social-linkedin.svg";
-import Image from "next/image";
 import useSupabaseAuth from "lib/hooks/useSupabaseAuth";
 import { cardImageUrl, linkedinCardShareUrl, twitterCardShareUrl } from "lib/utils/urls";
-import cntl from "cntl";
+import TwitterIcon from "../../../img/icons/social-twitter.svg";
+import LinkinIcon from "../../../img/icons/social-linkedin.svg";
+import BubbleBG from "../../../img/bubble-bg.svg";
 ;
 const ADDITIONAL_PROFILES_TO_LOAD = [
   "bdougie",


### PR DESCRIPTION
- Turns on lint rules for "import/order" and "no-unused-imports".
- Also ran `eslint --fix` on the entire
  codebase to automatically apply the new rules

The only file that was manually changed in this PR is 