### PR TITLE
fix: DevCard component first contribution date format

### DIFF
--- a/components/molecules/DevCard/dev-card.tsx
+++ b/components/molecules/DevCard/dev-card.tsx
@@ -235,7 +235,9 @@ export default function DevCard(props: DevCardProps) {
                   {props.age !== undefined && (
                     <div className="flex items-center">
                       <GiftIcon className="w-3 h-3 mr-1" />
-                      <div className="flex text-xs">{props.age}d</div>
+                      <div className="flex text-xs">
+                        {getRelativeDays(props.age)}
+                      </div>
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
This PR fixes the date format of the first contribution day on the `DevCard` component. The initial set-up displays the date in `days`.

```javascript
// insights/components/molecules/DevCard/dev-card.tsx
{props.age !== undefined && (
  <div className="flex items-center">
    ...
    <div className="flex text-xs">{props.age}d</div>
  </div>
)}
```
This fix leverages the `getRelativeDays` date utility function as there's a need to address first contributions that are `day`, `month` up to `year` old

```javascript
// insights/components/molecules/DevCard/dev-card.tsx
{props.age !== undefined && (
  <div className="flex items-center">
    ...
    <div className="flex text-xs">
      {getRelativeDays(props.age)}
    </div>
  </div>
)}
```
## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
fixes #1317 

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
BEFORE

![screenshot-localhost_3000-2023 06 30-15_38_55](https://github.com/open-sauced/insights/assets/25631971/6d04133f-0e02-4421-a47a-54ed4c4a569b) ![screenshot-localhost_3000-2023 06 30-15_39_50](https://github.com/open-sauced/insights/assets/25631971/9e2584b0-e45d-4dc1-bb5f-ffd97ebcba29)

AFTER


![screenshot-localhost_3000-2023 06 30-16_38_20](https://github.com/open-sauced/insights/assets/25631971/509b6f4f-a10b-4823-9d2e-b3deac1094d2) ![screenshot-localhost_3000-2023 06 30-16_37_18](https://github.com/open-sauced/insights/assets/25631971/ae68dcb0-35ba-4a35-bb18-306007881786)


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
NA

## [optional] What gif best describes this PR or how it makes you feel?


<!-- note: PRs with deleted sections will be marked invalid -->

