### PR TITLE
feat: implemented  tracking on every share button

### DIFF
--- a/components/molecules/InsightHeader/insight-header.tsx
+++ b/components/molecules/InsightHeader/insight-header.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { FaEdit } from "react-icons/fa";
 import Link from "next/link";
+import { usePostHog } from "posthog-js/react";
 
 import { FiCopy } from "react-icons/fi";
 
@@ -26,16 +27,17 @@ const InsightHeader = ({ insight, repositories, insightId, isOwner }: InsightHea
   const { repoList } = getRepoInsights(repoData);
   const [insightPageLink, setInsightPageLink] = useState("");
   const { toast } = useToast();
+  const posthog = usePostHog();
 
   useEffect(() => {
     if (typeof window !== "undefined") {
       setInsightPageLink(window.location.href);
-
     }
   }, [insight]);
 
   const handleCopyToClipboard = async (content: string) => {
     const url = new URL(content).toString();
+    posthog!.capture("clicked: Insights copied");
 
     try {
       await navigator.clipboard.writeText(url);


### PR DESCRIPTION
<!--
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

Added analytics tracking for contributor highlight card and insight header

- Added `usePostHog` hook from `posthog-js/react` library to track user actions
- Implemented tracking for sharing highlights on LinkedIn, Twitter, and copying highlight link to clipboard
- Implemented tracking for copying insight link to clipboard

This PR adds analytics tracking to the contributor highlight card and insight header components, allowing us to gather data on user interactions and engagement.



<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## Related Tickets & Documents
Fixes #1324 
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

