### PR TITLE
fix: contributor distribution chart yscale max height

### DIFF
--- a/components/molecules/NivoScatterChart/nivo-scatter-chart.tsx
+++ b/components/molecules/NivoScatterChart/nivo-scatter-chart.tsx
@@ -165,7 +165,7 @@ const NivoScatterPlot = ({
           yScale={{
             type: isLogarithmic ? "symlog" : "linear",
             min: 0,
-            max: Math.max(Math.round(maxFilesModified * 3), 10),
+            max: Math.max(Math.round(maxFilesModified * 1.5), 10),
           }}
           blendMode="normal"
           useMesh={false}


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->
The PR fixes the excessive whitespace between the maximum Lines Touched by a contributor and the maximum height of the Contributor Distribution Chart on the Dashboard.

The current set-up dynamically takes the `maxFilesModified` value, multiplies it by `3` to get the max value on the chart's `yScale` as can be seen in the file below

```javascript
// components\molecules\NivoScatterChart\nivo-scatter-chart.tsx

<ResponsiveScatterPlot
  //...
  yScale={{
    //...
    max: Math.max(Math.round(maxFilesModified * 3), 10),
  }}
  //...
/>
```

This causes the chart to have almost 2x in whitespace more than the max number of Lines touched.

I have approached this fix by reducing the multiplied value from `3` to `1.5`. This helped reduce the whitespace and distributed the stacked contributors better.

```javascript
max: Math.max(Math.round(maxFilesModified * 1.5), 10)
```

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #1253 

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
**BEFORE**

![screenshot-localhost_3000-2023 07 04-07_49_32](https://github.com/open-sauced/insights/assets/25631971/0a15db8b-a387-449d-b5cf-e29875fe31ca)


**AFTER**

![screenshot-localhost_3000-2023 07 04-07_41_38](https://github.com/open-sauced/insights/assets/25631971/8dd6522f-5515-49d6-a107-9583ff3c4780)


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?
NA

## [optional] What gif best describes this PR or how it makes you feel?
_Where do y'all get those dope GIF???_

<!-- note: PRs with deleted sections will be marked invalid -->

