### PR TITLE
fix: Move card image api route

### DIFF
--- a/lib/utils/urls.ts
+++ b/lib/utils/urls.ts
@@ -19,7 +19,7 @@ export const siteUrl = (path: string = "") => {
  */
 export const cardPageUrl = (username: string) => siteUrl(`user/${username}/card`);
 
-export const cardImageUrl = (username: string) => siteUrl(`api/card.png?username=${username}`);
+export const cardImageUrl = (username: string) => siteUrl(`api/user/${username}/card.png`);
 
 export const twitterCardShareUrl = (username: string) => {
   const url = new URL("https://twitter.com/intent/tweet");

--- a/pages/api/user/[username]/card.png.tsx
+++ b/pages/api/user/[username]/card.png.tsx
@@ -29,7 +29,7 @@ const interBlackFont = fetch(new URL("../../../../font/Inter-Black.ttf", import.
 export default async function handler(request: NextRequest) {
   // pull username from the request url
   // at /api/user/[username]/card.png
-  const username = request.nextUrl.searchParams.get("username");
+  const username = new URL(request.url).pathname?.split("/")[3];
 
   if (!username) {
     return new Response("A username must be specified", { status: 403 });

--- a/pages/api/user/[username]/card.png.tsx
+++ b/pages/api/user/[username]/card.png.tsx
@@ -1,5 +1,5 @@
-import { NextRequest } from "next/server";
 import { ImageResponse } from "@vercel/og";
+import { NextRequest } from "next/server";
 import { getAvatarByUsername } from "lib/utils/github";
 import { fetchContributorPRs } from "lib/hooks/api/useContributorPullRequests";
 import { getRepoList } from "lib/hooks/useRepoList";
@@ -9,33 +9,36 @@ import { getRepoList } from "lib/hooks/useRepoList";
  * @params {number} w - Width of the card
  */
 
-export const config = {
-  runtime: "edge",
-};
-
 const ASPECT_RATIO = 245 / 348;
 const BASE_WIDTH = 245;
 const DEFAULT_WIDTH = 735;
 const MAX_WIDTH = 1960;
 
-// Make sure the font exists in the specified path:
-const logoImg = fetch(new URL("../../img/openSauced-icon.png", import.meta.url)).then((res) => res.arrayBuffer());
-const interSemiBoldFont = fetch(new URL("../../font/Inter-SemiBold.ttf", import.meta.url)).then((res) =>
+export const config = {
+  runtime: "edge",
+};
+
+const logoImg = fetch(new URL("../../../../img/openSauced-icon.png", import.meta.url)).then((res) => res.arrayBuffer());
+const interSemiBoldFont = fetch(new URL("../../../../font/Inter-SemiBold.ttf", import.meta.url)).then((res) =>
   res.arrayBuffer()
 );
-const interBlackFont = fetch(new URL("../../font/Inter-Black.ttf", import.meta.url)).then((res) => res.arrayBuffer());
+const interBlackFont = fetch(new URL("../../../../font/Inter-Black.ttf", import.meta.url)).then((res) =>
+  res.arrayBuffer()
+);
 
 export default async function handler(request: NextRequest) {
-  const { searchParams } = new URL(request.url);
-  const username = searchParams.get("username");
+  // pull username from the request url
+  // at /api/user/[username]/card.png
+  const username = request.nextUrl.searchParams.get("username");
 
   if (!username) {
     return new Response("A username must be specified", { status: 403 });
   }
 
-  const requestedWidth = Number.parseInt(searchParams.get("w") ?? "0", 10) || DEFAULT_WIDTH;
+  // const requestedWidth = Number.parseInt(searchParams.get("w") ?? "0", 10) || DEFAULT_WIDTH;
 
-  const width = Math.min(requestedWidth, MAX_WIDTH);
+  // const width = Math.min(requestedWidth, MAX_WIDTH);
+  const width = DEFAULT_WIDTH;
   const height = width / ASPECT_RATIO;
   const avatarURL = getAvatarByUsername(username, 600);
 


### PR DESCRIPTION
## Description

 I think we're running into this netlify caching issue for the static image endpoint. https://answers.netlify.com/t/netlify-function-with-query-strings-ignores-custom-cache-control-header/15390/1
I can reproduce it if i go to one of these URLs and then the other one.

- https://insights.opensauced.pizza/api/card.png?username=foxyblocks
- https://insights.opensauced.pizza/api/card.png?username=bdougie

This change moves the endpoint so that the username parameter is part of the path so the cache is correctly busted for different users.

I've yet to figure out how to access these parameters from the request other than doing string parsing. `request.nextUrl.searchParams.get('username')` works locally but doesn't work when deploying to netlify, probably due to some difference in runtime environment.

## What type of PR is this? (check all applicable)

- [x] 🐛 Bug Fix

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

