### PR TITLE
fix: tab inconsistency in user profile matching the url

### DIFF
--- a/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
+++ b/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
@@ -66,9 +66,11 @@ const ContributorProfileTab = ({
   const hasHighlights = highlights?.length > 0;
   pathnameRef.current = router.pathname.split("/").at(-1);
 
-  const currentPathname =
-    pathnameRef.current !== "[username]" ? pathnameRef.current : hasHighlights ? "highlights" : "contributions";
+  const getCurrentPathName = () => {
+    return pathnameRef.current !== "[username]" ? pathnameRef.current : hasHighlights ? "highlights" : "contributions";
+  };
 
+  const [currentPathname, setCurrentPathname] = useState(getCurrentPathName());
   const handleTabUrl = (tab: string) => {
     router.push(`/user/${login}/${tab.toLowerCase()}`);
   };
@@ -76,12 +78,16 @@ const ContributorProfileTab = ({
   useEffect(() => {
     setInputVisible(highlights && highlights.length !== 0 ? true : false);
     if (login && currentPathname) {
-      router.push(`/user/${login}/${currentPathname}`);
+      if (currentPathname === "highlights" && !hasHighlights) {
+        setCurrentPathname("contributions");
+      } else {
+        router.push(`/user/${login}/${currentPathname}`);
+      }
     }
-  }, [highlights]);
+  }, [highlights, currentPathname]);
 
   return (
-    <Tabs defaultValue={uppercaseFirst(currentPathname as string)} className="" onValueChange={handleTabUrl}>
+    <Tabs value={uppercaseFirst(currentPathname as string)} className="" onValueChange={handleTabUrl}>
       <TabsList className="justify-start w-full overflow-x-auto border-b">
         {tabLinks.map((tab) => (
           <TabsTrigger

--- a/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
+++ b/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
@@ -57,7 +57,7 @@ const ContributorProfileTab = ({
 
   const { data: highlights, isError, isLoading, mutate, meta, setPage } = useFetchUserHighlights(login || "");
   const { data: emojis } = useFetchAllEmojis();
-  const [hasHighlights, setHasHighlights] = useState(highlights?.length > 0);
+  const [hasHighlights, setHasHighlights] = useState(true);
 
   const [inputVisible, setInputVisible] = useState(false);
   const pathnameRef = useRef<string | null>();
@@ -90,7 +90,7 @@ const ContributorProfileTab = ({
       router.push(`/user/${login}/contributions`);
       setCurrentPathname("contributions");
     }
-  }, [highlights]);
+  }, [currentPathname, hasHighlights, highlights, login]);
 
   useEffect(() => {
     // sets the highlights state to true if the user has highlights on profile route change

--- a/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
+++ b/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import clsx from "clsx";
 import formatDistanceToNowStrict from "date-fns/formatDistanceToNowStrict";
@@ -66,28 +66,34 @@ const ContributorProfileTab = ({
   const hasHighlights = highlights?.length > 0;
   pathnameRef.current = router.pathname.split("/").at(-1);
 
-  const getCurrentPathName = () => {
-    return pathnameRef.current !== "[username]" ? pathnameRef.current : hasHighlights ? "highlights" : "contributions";
-  };
+  const getCurrentPathName = useMemo(() => {
+    return pathnameRef.current && pathnameRef.current !== "[username]"
+      ? pathnameRef.current
+      : hasHighlights
+      ? "highlights"
+      : "contributions";
+  }, [hasHighlights]);
 
-  const [currentPathname, setCurrentPathname] = useState(getCurrentPathName());
+  const [currentPathname, setCurrentPathname] = useState(getCurrentPathName);
   const handleTabUrl = (tab: string) => {
     router.push(`/user/${login}/${tab.toLowerCase()}`);
+    setCurrentPathname(tab.toLowerCase());
   };
 
   useEffect(() => {
     setInputVisible(highlights && highlights.length !== 0 ? true : false);
     if (login && currentPathname) {
-      if (currentPathname === "highlights" && !hasHighlights) {
-        setCurrentPathname("contributions");
-      } else {
-        router.push(`/user/${login}/${currentPathname}`);
-      }
+      router.push(`/user/${login}/${currentPathname}`);
+      setCurrentPathname(getCurrentPathName);
     }
-  }, [highlights, currentPathname]);
+    if (login && !hasHighlights) {
+      router.push(`/user/${login}/contributions`);
+      setCurrentPathname("contributions");
+    }
+  }, [highlights]);
 
   return (
-    <Tabs value={uppercaseFirst(currentPathname as string)} className="" onValueChange={handleTabUrl}>
+    <Tabs value={uppercaseFirst(currentPathname as string)} onValueChange={handleTabUrl}>
       <TabsList className="justify-start w-full overflow-x-auto border-b">
         {tabLinks.map((tab) => (
           <TabsTrigger

--- a/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
+++ b/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
@@ -57,13 +57,13 @@ const ContributorProfileTab = ({
 
   const { data: highlights, isError, isLoading, mutate, meta, setPage } = useFetchUserHighlights(login || "");
   const { data: emojis } = useFetchAllEmojis();
+  const [hasHighlights, setHasHighlights] = useState(highlights?.length > 0);
 
   const [inputVisible, setInputVisible] = useState(false);
   const pathnameRef = useRef<string | null>();
 
   const router = useRouter();
 
-  const hasHighlights = highlights?.length > 0;
   pathnameRef.current = router.pathname.split("/").at(-1);
 
   const getCurrentPathName = useMemo(() => {
@@ -89,6 +89,13 @@ const ContributorProfileTab = ({
     if (login && !hasHighlights) {
       router.push(`/user/${login}/contributions`);
       setCurrentPathname("contributions");
+    }
+  }, [highlights]);
+
+  useEffect(() => {
+    // sets the highlights state to true if the user has highlights on profile route change
+    if (highlights) {
+      setHasHighlights(highlights?.length > 0);
     }
   }, [highlights]);
 


### PR DESCRIPTION
## Description
This PR fixes the issue with tab inconsistency on the user profile page. Before now, when you visit a user profile with no highlights, the Highlights tab is active but hidden, leaving the contributors tab inactive but visible and blank. 

This PR fixes the issue by making the `hasHighlights` variable a state and updating the state with a `useMemo` hook to prevent unnecessary rerenders
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
Fixes #1402
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Mobile & Desktop Screenshots/Recordings


https://github.com/open-sauced/insights/assets/62995161/65e72666-5731-409a-af03-53ccfbbabc98



<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/3o6Zt4RZxXV6WcUlZC/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
