### PR TITLE
fix: misaligned chat close button icon

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,9 +5,15 @@
 * {
   font-weight: 500;
 }
+
 body {
   background-color: #f8f9fa;
 }
+
+#sitegpt-chat-icon {
+  display: flex !important;
+}
+
 .login-step .sbui-btn-container {
   width: 100%;
 }
@@ -16,13 +22,18 @@ body {
   display: flex;
   align-items: center;
 }
+
 .sbui-select:focus-visible {
   border: 1px solid #f76808 !important  ;
-  box-shadow: 0px 0px 0px 2px #ffcca7, 0px 1px 2px rgba(0, 0, 0, 0.1) !important;
+  box-shadow:
+    0px 0px 0px 2px #ffcca7,
+    0px 1px 2px rgba(0, 0, 0, 0.1) !important;
 }
+
 .sbui-checkbox:hover {
   border-color: #f76808 !important;
 }
+
 input[type="search"]::-webkit-search-cancel-button {
   -webkit-appearance: none !important;
 }


### PR DESCRIPTION
## Description

This PR fixes the issue of the misaligned chat close button icon. I also formatted the globals.css file better.

## What type of PR is this?

- [x] 🐛 Bug Fix
- [x] 🎨 Style
- [x] 🧑‍💻 Code Refactor

## Related Tickets:

Fixes #1407

## Desktop Screenshot:

![255882448-7e652702-ad5c-4aee-ba47-5c1b0c606090](https://github.com/open-sauced/insights/assets/95426296/e84f120b-079e-4c2e-96c9-713fc2a187ee)

## Added tests?

- [x] 🙅 no, because they aren't needed

## Added to documentation?

- [x] 🙅 no documentation needed