### PR TITLE
fix: contributor profile tab click state flicker

### DIFF
--- a/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
+++ b/components/organisms/ContributorProfileTab/contributor-profile-tab.tsx
@@ -83,14 +83,14 @@ const ContributorProfileTab = ({
   useEffect(() => {
     setInputVisible(highlights && highlights.length !== 0 ? true : false);
     if (login && currentPathname) {
-      router.push(`/user/${login}/${currentPathname}`);
       setCurrentPathname(getCurrentPathName);
+      router.push(`/user/${login}/${currentPathname}`);
     }
-    if (login && !hasHighlights) {
-      router.push(`/user/${login}/contributions`);
-      setCurrentPathname("contributions");
+    if (login && !hasHighlights && currentPathname) {
+      setCurrentPathname(currentPathname);
+      router.push(`/user/${login}/${currentPathname}`);
     }
-  }, [currentPathname, hasHighlights, highlights, login]);
+  }, [login, hasHighlights]);
 
   useEffect(() => {
     // sets the highlights state to true if the user has highlights on profile route change
@@ -100,7 +100,7 @@ const ContributorProfileTab = ({
   }, [highlights]);
 
   return (
-    <Tabs value={uppercaseFirst(currentPathname as string)} onValueChange={handleTabUrl}>
+    <Tabs defaultValue={uppercaseFirst(currentPathname as string)} onValueChange={handleTabUrl}>
       <TabsList className="justify-start w-full overflow-x-auto border-b">
         {tabLinks.map((tab) => (
           <TabsTrigger
@@ -262,8 +262,8 @@ const ContributorProfileTab = ({
                 )}
               </div>
             </div>
-            <div className="h-32 mt-10">
-              <CardLineChart lineChartOption={chart} className="!h-32" />
+            <div className="mt-2 h-36">
+              <CardLineChart lineChartOption={chart} className="!h-36" />
             </div>
             <div>
               <CardRepoList limit={7} repoList={repoList} />

--- a/lib/hooks/useContributorPullRequestsChart.ts
+++ b/lib/hooks/useContributorPullRequestsChart.ts
@@ -23,7 +23,7 @@ const useContributorPullRequestsChart = (contributor: string, topic: string, rep
       },
     },
     grid: {
-      height: 100,
+      height: 130,
       top: 0,
       bottom: 0,
       right: 0,
@@ -41,6 +41,7 @@ const useContributorPullRequestsChart = (contributor: string, topic: string, rep
           color: "#FFB74D",
           opacity: 0.6,
         },
+        clip: false,
       },
     ],
     tooltip: {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -58,8 +58,6 @@ function MyApp({ Component, pageProps }: ComponentWithPageLayout) {
 
   if (typeof window !== "undefined") hostname = window.location.hostname;
 
-  console.log(router.asPath);
-
   useEffect(() => {
     let chatButton = document.getElementById("sitegpt-chat-icon");
 


### PR DESCRIPTION
## Description
This PR fixes a bug with the user profile tab toggle. refer to video and before and after below for more context.

The intention was initially to fix the contributions graph cut in the user's profile. After going through the charts library docs, I found this option https://echarts.apache.org/en/option.html#series-line.clip which is set to true by default and Clips all the overflowed lines. Not sure this fixes the issue, and that can be confirmed in this PR 😅 . I also increased the height of the chart and reduce to margin from top in relation to its siblings.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #1285 
## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
### Profile Tab Before
https://github.com/open-sauced/insights/assets/62995161/2aa11132-e838-4481-9765-5ba5ae1cab31

### Profile Tab After

https://github.com/open-sauced/insights/assets/62995161/4ea8f941-fa43-492c-868e-dd2857a4725a

### Chart Before
![Screenshot 2023-07-26 at 15 32 59](https://github.com/open-sauced/insights/assets/62995161/4164c1fc-6b00-42a4-8b95-84e0b2483176)


### Chart After
![Screenshot 2023-07-26 at 15 31 54](https://github.com/open-sauced/insights/assets/62995161/0a4d2e24-c0b1-4ed0-abf2-15468b15cf77)


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media1.giphy.com/media/xTiN0CNHgoRf1Ha7CM/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
