### PR TITLE
fix: add id to checkbox, add link to profiles

### DIFF
--- a/components/atoms/Checkbox/checkbox.tsx
+++ b/components/atoms/Checkbox/checkbox.tsx
@@ -9,31 +9,34 @@ interface CheckboxProps extends React.ComponentPropsWithoutRef<typeof CheckboxPr
 }
 
 const Checkbox = React.forwardRef<React.ElementRef<typeof CheckboxPrimitive.Root>, CheckboxProps>(
-  ({ className, label, id = "checkbox", ...props }, ref) => (
-    <div className="flex items-center">
-      <CheckboxPrimitive.Root
-        ref={ref}
-        className={clsx(
-          "peer h-4 w-4 shrink-0 rounded-[4px] cursor-pointer bg-white border border-light-slate-8 hover:border-orange-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-orange-500 data-[state=checked]:bg-orange-500",
-          className
-        )}
-        {...props}
-        id={id}
-      >
-        <CheckboxPrimitive.Indicator className={clsx("flex items-center justify-center text-white")}>
-          <FiCheck className="w-full h-full" />
-        </CheckboxPrimitive.Indicator>
-      </CheckboxPrimitive.Root>
-      {label && (
-        <label
-          htmlFor={id}
-          className="ml-3 text-sm font-medium leading-none cursor-pointer text-light-slate-12 peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+  ({ className, label, id, ...props }, ref) => {
+    id = id ? id : label?.replaceAll(" ", "_").toLowerCase();
+    return (
+      <div className="flex items-center">
+        <CheckboxPrimitive.Root
+          ref={ref}
+          className={clsx(
+            "peer h-4 w-4 shrink-0 rounded-[4px] cursor-pointer bg-white border border-light-slate-8 hover:border-orange-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-orange-500 data-[state=checked]:bg-orange-500",
+            className
+          )}
+          {...props}
+          id={id}
         >
-          {label}
-        </label>
-      )}
-    </div>
-  )
+          <CheckboxPrimitive.Indicator className={clsx("flex items-center justify-center text-white")}>
+            <FiCheck className="w-full h-full" />
+          </CheckboxPrimitive.Indicator>
+        </CheckboxPrimitive.Root>
+        {label && (
+          <label
+            htmlFor={id}
+            className="ml-3 text-sm font-medium leading-none cursor-pointer text-light-slate-12 peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+          >
+            {label}
+          </label>
+        )}
+      </div>
+    );
+  }
 );
 Checkbox.displayName = CheckboxPrimitive.Root.displayName;
 

--- a/components/atoms/Checkbox/checkbox.tsx
+++ b/components/atoms/Checkbox/checkbox.tsx
@@ -10,7 +10,7 @@ interface CheckboxProps extends React.ComponentPropsWithoutRef<typeof CheckboxPr
 
 const Checkbox = React.forwardRef<React.ElementRef<typeof CheckboxPrimitive.Root>, CheckboxProps>(
   ({ className, label, id, ...props }, ref) => {
-    id = id ? id : label?.replaceAll(" ", "_").toLowerCase();
+    const getId = () => id ? id : label?.replaceAll(" ", "_").toLowerCase();
     return (
       <div className="flex items-center">
         <CheckboxPrimitive.Root
@@ -20,7 +20,7 @@ const Checkbox = React.forwardRef<React.ElementRef<typeof CheckboxPrimitive.Root
             className
           )}
           {...props}
-          id={id}
+          id={getId()}
         >
           <CheckboxPrimitive.Indicator className={clsx("flex items-center justify-center text-white")}>
             <FiCheck className="w-full h-full" />
@@ -28,7 +28,7 @@ const Checkbox = React.forwardRef<React.ElementRef<typeof CheckboxPrimitive.Root
         </CheckboxPrimitive.Root>
         {label && (
           <label
-            htmlFor={id}
+            htmlFor={getId()}
             className="ml-3 text-sm font-medium leading-none cursor-pointer text-light-slate-12 peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
           >
             {label}

--- a/components/atoms/Checkbox/checkbox.tsx
+++ b/components/atoms/Checkbox/checkbox.tsx
@@ -16,7 +16,7 @@ const Checkbox = React.forwardRef<React.ElementRef<typeof CheckboxPrimitive.Root
         <CheckboxPrimitive.Root
           ref={ref}
           className={clsx(
-            "peer h-4 w-4 shrink-0 rounded-[4px] cursor-pointer bg-white border border-light-slate-8 hover:border-orange-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-orange-500 data-[state=checked]:bg-orange-500",
+            "peer h-4 w-4 shrink-0 rounded cursor-pointer bg-white border border-light-slate-8 hover:border-orange-500 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:border-orange-500 data-[state=checked]:bg-orange-500",
             className
           )}
           {...props}

--- a/components/atoms/UserCard/user-card.tsx
+++ b/components/atoms/UserCard/user-card.tsx
@@ -32,9 +32,9 @@ const UserCard = ({ username, name, meta, loading }: UserCardProps) => {
               src={avatarUrl}
               alt={`${username}'s avatar image`}
             />
-            <div>
+            <div className="text-center">
               <h3 className="text-base text-center">{name}</h3>
-              <p className="text-center text-light-slate-9">{`@${username}`}</p>
+              <a className="text-center text-light-slate-9" href={`/user/${username}`}>{`@${username}`}</a>
             </div>
           </div>
           <div className="flex items-center gap-5 text-base text-center ">

--- a/components/molecules/ContributorProfileInfo/contributor-profile-info.tsx
+++ b/components/molecules/ContributorProfileInfo/contributor-profile-info.tsx
@@ -54,7 +54,7 @@ const ContributorProfileInfo = ({
           {isConnected && <Badge text="beta" />}
         </div>
         <div className="flex items-center text-sm gap-3">
-          <span className="text-light-slate-11 text-sm">{`@${githubName}`}</span>
+          <a className="text-light-slate-11 text-sm" href={`https://github.coom/${githubName}`}>{`@${githubName}`}</a>
 
           {isConnected && (
             <>

--- a/components/molecules/ContributorProfileInfo/contributor-profile-info.tsx
+++ b/components/molecules/ContributorProfileInfo/contributor-profile-info.tsx
@@ -54,7 +54,7 @@ const ContributorProfileInfo = ({
           {isConnected && <Badge text="beta" />}
         </div>
         <div className="flex items-center text-sm gap-3">
-          <a className="text-light-slate-11 text-sm" href={`https://github.coom/${githubName}`}>{`@${githubName}`}</a>
+          <a className="text-light-slate-11 text-sm" href={`https://github.com/${githubName}`}>{`@${githubName}`}</a>
 
           {isConnected && (
             <>


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

This PR adds redirect to profile page like the next: 
- In the feed page, the mention/tag to username redirects to OpenSauced profile 
- In the user page, the mention/tag redirects to GitHub Profle 

Beside the redirects, it fixes the label/input connection issue in the pages with multiple checkboxes, if the check box has no ID. the default id would be checkbox which will break the UI due to having multiple similar IDs, I fixed this by using the label as ID, to avoid any issue in the future and make the ID as an optional for programmer for easier coding. 

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #1447
Fixes #1199
Fixes #1448

## Mobile & Desktop Screenshots/Recordings

This link in the profile page is redirecting to GitHub: 
![image](https://github.com/open-sauced/insights/assets/18273833/a697159d-b0c1-461e-929b-a5d6c98aebab)

To test:
- go to a user profile: https://insights.opensauced.pizza/user/a0m0rajab/highlights
- click on the mention (tag) under their profile
- Check if it's redirecting to the GitHub

This link in the feed page redirects to OpenSauced Profile:
![image](https://github.com/open-sauced/insights/assets/18273833/36617286-5dbe-40e4-b09d-aec67f19af6f)

To test
- go to the feed page: https://insights.opensauced.pizza/feed
- Click on the profile (mention) 
- Check if it's redirecting to the open sauced user page

The checkbox elements and labels are connected to their related inputs:
![image](https://github.com/open-sauced/insights/assets/18273833/d1e94954-3a98-49a2-89f8-17cfadc83ef6)

To Test you need to do the next: 
- Go to: https://insights.opensauced.pizza/user/settings 
- Click on the check boxes labels one and see if their related check box is triggered(display email, collaboration, timezone)

# Deploy Test Links: 

- https://deploy-preview-1449--oss-insights.netlify.app/feed
- https://deploy-preview-1449--oss-insights.netlify.app/user/a0m0rajab
- https://deploy-preview-1449--oss-insights.netlify.app/user/settings


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [x] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?

<img src="https://media2.giphy.com/media/PApUm1HPVYlDNLoMmr/giphy.gif"/>

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
