### PR TITLE
feat: improved the UX on the feeds page and scroll behaviour

### DIFF
--- a/components/molecules/AnnouncementCard/announcement-card.tsx
+++ b/components/molecules/AnnouncementCard/announcement-card.tsx
@@ -9,7 +9,7 @@ interface AnnouncementCardProps {
 }
 const AnnouncementCard = ({ title, description, bannerSrc, url }: AnnouncementCardProps) => {
   return (
-    <div className="overflow-hidden border rounded-lg bg-light-slate-1">
+    <div className="overflow-hidden border max-w-xs  rounded-lg bg-light-slate-1">
       <div className="w-full p-0.5 ">
         <AspectRatio.Root ratio={1.85 / 1}>
           <picture>

--- a/components/organisms/TopNav/top-nav.tsx
+++ b/components/organisms/TopNav/top-nav.tsx
@@ -18,7 +18,7 @@ const TopNav: React.FC = () => {
   const router = useRouter();
 
   return (
-    <header className="top-nav-container flex justify-between items-center z-50 py-0.5 bg-light-slate-3 border-b">
+    <header className="top-nav-container w-full fixed top-0 left-0 flex justify-between items-center z-50 py-0.5 bg-light-slate-3 border-b">
       <div className="flex justify-between items-start sm:items-center mx-auto container px-2 md:px-16">
         <div className="flex gap-3 md:gap-8 items-center flex-wrap">
           <HeaderLogo withBg={false} textIsBlack />

--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -127,32 +127,34 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
         twitterCard="summary_large_image"
       />
       <div
-        className="container flex flex-col gap-16 px-2 pt-12 mx-auto md:px-16 lg:justify-end md:flex-row"
+        className="container flex flex-col gap-16 px-2 pt-12 md:items-start md:justify-between mx-auto md:px-16 lg:justify-end md:flex-row"
         ref={topRef}
       >
-        <div className="flex-col flex-1 hidden gap-6 mt-12 md:flex">
-          {user && (
-            <div>
-              <UserCard
-                loading={loggedInUserLoading}
-                username={loggedInUser?.login as string}
-                meta={userMetaArray as MetaObj[]}
-                name={loggedInUser?.name as string}
-              />
-            </div>
-          )}
-          <TopContributorsPanel loggedInUserLogin={loggedInUser?.login ?? ""} />
+        <div className="sticky top-8">
+          <div className="flex-col flex-1 hidden gap-6 mt-12 md:flex">
+            {user && (
+              <div>
+                <UserCard
+                  loading={loggedInUserLoading}
+                  username={loggedInUser?.login as string}
+                  meta={userMetaArray as MetaObj[]}
+                  name={loggedInUser?.name as string}
+                />
+              </div>
+            )}
+            <TopContributorsPanel loggedInUserLogin={loggedInUser?.login ?? ""} />
 
-          <AnnouncementCard
-            title="#100DaysOfOSS 🚀 "
-            description={
-              "Join us for 100 days of supporting, sharing knowledge, and exploring the open source ecosystem together."
-            }
-            bannerSrc={
-              "https://user-images.githubusercontent.com/5713670/254358937-8e9aa76d-4ed3-4616-a58a-2283796b10e1.png"
-            }
-            url={"https://dev.to/opensauced/100daysofoss-growing-skills-and-real-world-experience-3o5k"}
-          />
+            <AnnouncementCard
+              title="#100DaysOfOSS 🚀 "
+              description={
+                "Join us for 100 days of supporting, sharing knowledge, and exploring the open source ecosystem together."
+              }
+              bannerSrc={
+                "https://user-images.githubusercontent.com/5713670/254358937-8e9aa76d-4ed3-4616-a58a-2283796b10e1.png"
+              }
+              url={"https://dev.to/opensauced/100daysofoss-growing-skills-and-real-world-experience-3o5k"}
+            />
+          </div>
         </div>
         {singleHighlight && (
           <Dialog
@@ -284,7 +286,7 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
             <FollowingHighlightWrapper selectedFilter={selectedRepo} emojis={emojis} />
           </TabsContent>
         </Tabs>
-        <div className="hidden gap-6 mt-10 md:flex-1 md:flex md:flex-col">
+        <div className="hidden gap-6 mt-10 md:flex-1 md:flex md:flex-col sticky top-20">
           {repoList && repoList.length > 0 && (
             <HighlightsFilterCard
               selectedFilter={selectedRepo}


### PR DESCRIPTION
## Description
**Issue:** Currently, there is an issue where the _highlight filters_ and _user card_ scroll along with the content when scrolling through the feed. This behaviour is not user-friendly and can lead to confusion and a bad user experience.

**Changes Proposed:**
In this pull request, i addressed the scrolling behaviour to enhance the overall user experience and ensure a smoother and more intuitive interaction with the feed. The following changes have been implemented:

1. Fixed Position for Navigation Menu: The navigation menu is now set to have a fixed position as the user scrolls through the feed. This means that the navigation menu will remain visible at the top, offering users quick access to navigation options.

2. Sticky Position for Filters and User Card: The filters and user card sections are now set to have a sticky position as the user scrolls through the feed. This means that these elements will remain visible at their designated positions, offering users quick access to important information and controls without any disruption caused by scrolling.

3. Smooth Transition: To maintain a visually pleasing transition, i have incorporated a smooth scrolling effect when transitioning between different sections of the feed. This ensures that the user's focus remains on the content while seamlessly interacting with the filters and user card.
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #1353 and Fixes #1451 
## Mobile & Desktop Screenshots/Recordings
![image](https://github.com/open-sauced/insights/assets/72051159/05829b2c-5243-4749-88a0-69a4820a8a4e)

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
