### PR TITLE
fix: UserCard leaves the viewport on sticky sidebar

### DIFF
--- a/pages/feed/index.tsx
+++ b/pages/feed/index.tsx
@@ -184,7 +184,7 @@ const Feeds: WithPageLayout<HighlightSSRProps> = (props: HighlightSSRProps) => {
         className="container mt-5 md:mt-0 w-full gap-12 flex flex-col justify-center px-2 pt-12 md:items-start md:px-16 md:flex-row"
         ref={topRef}
       >
-        <div className="sticky top-8 xl:flex hidden flex-none w-[22%]">
+        <div className={`sticky ${user ? "top-16" : "top-8"} xl:flex hidden flex-none w-[22%]`}>
           <div className="flex flex-col w-full gap-6 mt-12">
             {user && (
               <div className="w-full">


### PR DESCRIPTION
## Description
Refactored the sticky positioning of the sidebar on the feed page. The sidebar will now be positioned 16 pixels from the top if a user is logged in, and 8 pixels from the top if no user is logged in. This change ensures a consistent and visually appealing layout for both scenarios.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #1579

## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->
Before:

[screencast-insights.opensauced.pizza-2023.08.19-17_04_16.webm](https://github.com/open-sauced/insights/assets/25631971/9f2f7c0f-9896-4c33-9462-7482b1240f5f)

After:


https://github.com/open-sauced/insights/assets/106407013/18ed2281-aeb5-4537-9bfa-c19c3c16885d

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.opensauced.pizza
- [ ] 🍕 dev.to/opensauced
- [ ] 📕 storybook
- [x] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?



## [optional] What gif best describes this PR or how it makes you feel?



<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 📖 Read the Open Sauced Contributing Guide: https://github.com/open-sauced/.github/blob/main/CONTRIBUTING.md.
  - 📖 Read the Open Sauced Code of Conduct: https://github.com/open-sauced/.github/blob/main/CODE_OF_CONDUCT.md.
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
